### PR TITLE
[PIL-1171] Do not send additional property to ETMP

### DIFF
--- a/app/uk/gov/hmrc/pillar2/connectors/SubscriptionConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/SubscriptionConnector.scala
@@ -21,7 +21,7 @@ import play.api.Logger
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.pillar2.config.AppConfig
-import uk.gov.hmrc.pillar2.models.hods.subscription.common.AmendSubscriptionSuccess
+import uk.gov.hmrc.pillar2.models.hods.subscription.common.{AmendSubscriptionSuccess, ETMPAmendSubscriptionSuccess}
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -53,12 +53,12 @@ class SubscriptionConnector @Inject() (
   }
 
   def amendSubscriptionInformation(
-    amendRequest: AmendSubscriptionSuccess
+    amendRequest: ETMPAmendSubscriptionSuccess
   )(implicit hc:  HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val serviceName = "create-subscription"
     val url         = s"${config.baseUrl(serviceName)}"
-    implicit val writes: Writes[AmendSubscriptionSuccess] = AmendSubscriptionSuccess.format
-    http.PUT[AmendSubscriptionSuccess, HttpResponse](
+    implicit val writes: Writes[ETMPAmendSubscriptionSuccess] = ETMPAmendSubscriptionSuccess.format
+    http.PUT[ETMPAmendSubscriptionSuccess, HttpResponse](
       url,
       amendRequest,
       extraHeaders(config, serviceName)

--- a/app/uk/gov/hmrc/pillar2/models/hods/subscription/common/ETMPAmendSubscriptionSuccess.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hods/subscription/common/ETMPAmendSubscriptionSuccess.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.models.hods.subscription.common
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.pillar2.models.AccountingPeriodAmend
+
+final case class ETMPAmendSubscriptionSuccess(
+  upeDetails:               UpeDetailsAmend,
+  accountingPeriod:         AccountingPeriodAmend,
+  upeCorrespAddressDetails: UpeCorrespAddressDetails,
+  primaryContactDetails:    ContactDetailsType,
+  secondaryContactDetails:  Option[ContactDetailsType],
+  filingMemberDetails:      Option[FilingMemberAmendDetails]
+)
+
+object ETMPAmendSubscriptionSuccess {
+
+  def apply(amendSubscriptionSuccess: AmendSubscriptionSuccess): ETMPAmendSubscriptionSuccess =
+    ETMPAmendSubscriptionSuccess(
+      amendSubscriptionSuccess.upeDetails,
+      amendSubscriptionSuccess.accountingPeriod,
+      amendSubscriptionSuccess.upeCorrespAddressDetails,
+      amendSubscriptionSuccess.primaryContactDetails,
+      amendSubscriptionSuccess.secondaryContactDetails,
+      amendSubscriptionSuccess.filingMemberDetails
+    )
+
+  implicit val format: OFormat[ETMPAmendSubscriptionSuccess] = Json.format[ETMPAmendSubscriptionSuccess]
+}

--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -432,8 +432,9 @@ class SubscriptionService @Inject() (
     )
   }
 
-  def sendAmendedData(id: String, amendData: AmendSubscriptionSuccess)(implicit hc: HeaderCarrier): Future[Done] =
-    subscriptionConnector.amendSubscriptionInformation(amendData).flatMap { response =>
+  def sendAmendedData(id: String, amendData: AmendSubscriptionSuccess)(implicit hc: HeaderCarrier): Future[Done] = {
+    val etmpAmendSubscriptionSuccess = ETMPAmendSubscriptionSuccess(amendData)
+    subscriptionConnector.amendSubscriptionInformation(etmpAmendSubscriptionSuccess).flatMap { response =>
       if (response.status == 200) {
         auditService.auditAmendSubscription(requestData = amendData, responseData = AuditResponseReceived(response.status, response.json))
         response.json.validate[AmendResponse] match {
@@ -453,5 +454,6 @@ class SubscriptionService @Inject() (
         Future.failed(UnexpectedResponse)
       }
     }
+  }
 
 }

--- a/test/uk/gov/hmrc/pillar2/connectors/SubscriptionConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/connectors/SubscriptionConnectorSpec.scala
@@ -26,7 +26,7 @@ import play.api.libs.json.{JsResultException, Json}
 import play.api.test.Helpers.await
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.hods.subscription.common.{AmendSubscriptionSuccess, SubscriptionResponse}
+import uk.gov.hmrc.pillar2.models.hods.subscription.common.{AmendSubscriptionSuccess, ETMPAmendSubscriptionSuccess, SubscriptionResponse}
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
 
 class SubscriptionConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
@@ -133,7 +133,7 @@ class SubscriptionConnectorSpec extends BaseSpec with Generators with ScalaCheck
     "amendSubscriptionInformation" - {
 
       "must return status as OK for a successful amendment" in {
-        forAll(arbitrary[AmendSubscriptionSuccess]) { amendRequest =>
+        forAll(arbitrary[ETMPAmendSubscriptionSuccess]) { amendRequest =>
           stubPutResponse(
             s"/pillar2/subscription",
             OK
@@ -145,7 +145,7 @@ class SubscriptionConnectorSpec extends BaseSpec with Generators with ScalaCheck
       }
 
       "should handle 400 Bad Request" in {
-        forAll { amendRequest: AmendSubscriptionSuccess =>
+        forAll { amendRequest: ETMPAmendSubscriptionSuccess =>
           stubPutResponse("/pillar2/subscription", BAD_REQUEST)
 
           val result = await(connector.amendSubscriptionInformation(amendRequest))
@@ -155,7 +155,7 @@ class SubscriptionConnectorSpec extends BaseSpec with Generators with ScalaCheck
       }
 
       "should handle exceptions" in {
-        forAll { amendRequest: AmendSubscriptionSuccess =>
+        forAll { amendRequest: ETMPAmendSubscriptionSuccess =>
           server.stop()
 
           val exception = intercept[Throwable] {

--- a/test/uk/gov/hmrc/pillar2/generators/ModelGenerators.scala
+++ b/test/uk/gov/hmrc/pillar2/generators/ModelGenerators.scala
@@ -800,6 +800,25 @@ trait ModelGenerators {
       filingMember = filingMember
     )
   }
+
+  implicit val arbitraryETMPAmendSubscriptionSuccess: Arbitrary[ETMPAmendSubscriptionSuccess] = Arbitrary {
+    for {
+      upeDetails               <- arbitrary[UpeDetailsAmend]
+      accountingPeriod         <- arbitrary[AccountingPeriodAmend]
+      upeCorrespAddressDetails <- arbitrary[UpeCorrespAddressDetails]
+      primaryContactDetails    <- arbitrary[ContactDetailsType]
+      secondaryContactDetails  <- Gen.option(arbitrary[ContactDetailsType])
+      filingMemberDetails      <- Gen.option(arbitrary[FilingMemberAmendDetails])
+    } yield ETMPAmendSubscriptionSuccess(
+      upeDetails,
+      accountingPeriod,
+      upeCorrespAddressDetails,
+      primaryContactDetails,
+      secondaryContactDetails,
+      filingMemberDetails
+    )
+  }
+
   implicit val arbitraryAmendSubscriptionSuccess: Arbitrary[AmendSubscriptionSuccess] = Arbitrary {
     for {
       replaceFilingMember      <- arbitrary[Boolean]


### PR DESCRIPTION
we are sending an additional property to ETMP but ETMP do not accept additionalProperties. In this case, we created separate domain events for audit and ETMP, removing the additional property.

This is tested and verified by an acceptance test