### PR TITLE
PIL-1185 - Modify Financial Data Retrieval to Use Single ETMP Call

### DIFF
--- a/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
@@ -60,7 +60,7 @@ class FinancialService @Inject() (
     }
 
     financialDataConnector
-      .retrieveFinancialData(plrReference, adjustedStartDate, dateTo)
+      .retrieveFinancialData(plrReference, dateFrom = adjustedStartDate, dateTo = dateTo)
       .map { financialDataResponse =>
         FinancialDataResponse(
           idType = financialDataResponse.idType,

--- a/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
@@ -50,13 +50,9 @@ class FinancialService @Inject() (
           Right(TransactionHistory(plrReference, sortedFinancialHistory))
         }
       }
-      .recover {
-        case e: FinancialDataError =>
-          logger.error(s"Error returned from getFinancials for plrReference=$plrReference - Error code=${e.code} Error reason=${e.reason}")
-          Left(e)
-        case e: Exception =>
-          logger.error(s"Unexpected error occurred for plrReference=$plrReference - ${e.getMessage}")
-          Left(FinancialDataError("UNKNOWN_ERROR", e.getMessage))
+      .recover { case e: FinancialDataError =>
+        logger.error(s"Error returned from getFinancials for plrReference=$plrReference - Error code=${e.code} Error reason=${e.reason}")
+        Left(e)
       }
 
   private def retrieveCompleteFinancialDataResponse(plrReference: String, dateFrom: LocalDate, dateTo: LocalDate)(implicit

--- a/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
@@ -35,20 +35,29 @@ class FinancialService @Inject() (
 
   def getTransactionHistory(plrReference: String, dateFrom: LocalDate, dateTo: LocalDate)(implicit
     hc:                                   HeaderCarrier
-  ): Future[Either[FinancialDataError, TransactionHistory]] = {
+  ): Future[Either[FinancialDataError, TransactionHistory]] =
+    retrieveCompleteFinancialDataResponse(plrReference, dateFrom, dateTo)
+      .map { financialData =>
+        val repaymentData = getRepaymentData(financialData)
+        val paymentData   = getPaymentData(financialData)
 
-    val result = for {
-      financialData <- retrieveCompleteFinancialDataResponse(plrReference, dateFrom, dateTo)
-      repaymentData <- Future successful getRepaymentData(financialData)
-      paymentData   <- Future successful getPaymentData(financialData)
-      sortedFinancialHistory = (paymentData ++ repaymentData).sortBy(_.paymentType).sortBy(_.date)(Ordering[LocalDate].reverse)
-    } yield Right(TransactionHistory(plrReference, sortedFinancialHistory))
-
-    result.recover { case e: FinancialDataError =>
-      logger.error(s"Error returned from getFinancials for plrReference=$plrReference - Error code=${e.code} Error reason=${e.reason}")
-      Left(e)
-    }
-  }
+        if (repaymentData.isEmpty && paymentData.isEmpty) {
+          Left(FinancialDataError("NOT_FOUND", "No relevant financial data found"))
+        } else {
+          val sortedFinancialHistory = (paymentData ++ repaymentData)
+            .sortBy(_.paymentType)
+            .sortBy(_.date)(Ordering[LocalDate].reverse)
+          Right(TransactionHistory(plrReference, sortedFinancialHistory))
+        }
+      }
+      .recover {
+        case e: FinancialDataError =>
+          logger.error(s"Error returned from getFinancials for plrReference=$plrReference - Error code=${e.code} Error reason=${e.reason}")
+          Left(e)
+        case e: Exception =>
+          logger.error(s"Unexpected error occurred for plrReference=$plrReference - ${e.getMessage}")
+          Left(FinancialDataError("UNKNOWN_ERROR", e.getMessage))
+      }
 
   private def retrieveCompleteFinancialDataResponse(plrReference: String, dateFrom: LocalDate, dateTo: LocalDate)(implicit
     headerCarrier:                                                HeaderCarrier
@@ -59,17 +68,7 @@ class FinancialService @Inject() (
       if (dateFrom.isBefore(sevenYearsAgo)) sevenYearsAgo else dateFrom
     }
 
-    financialDataConnector
-      .retrieveFinancialData(plrReference, dateFrom = adjustedStartDate, dateTo = dateTo)
-      .map { financialDataResponse =>
-        FinancialDataResponse(
-          idType = financialDataResponse.idType,
-          idNumber = financialDataResponse.idNumber,
-          regimeType = financialDataResponse.regimeType,
-          processingDate = financialDataResponse.processingDate,
-          financialTransactions = financialDataResponse.financialTransactions
-        )
-      }
+    financialDataConnector.retrieveFinancialData(plrReference, dateFrom = adjustedStartDate, dateTo = dateTo)
   }
 
   private def getPaymentData(response: FinancialDataResponse): Seq[FinancialHistory] =

--- a/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
@@ -52,9 +52,15 @@ class FinancialService @Inject() (
 
   private def retrieveCompleteFinancialDataResponse(plrReference: String, dateFrom: LocalDate, dateTo: LocalDate)(implicit
     headerCarrier:                                                HeaderCarrier
-  ): Future[FinancialDataResponse] =
+  ): Future[FinancialDataResponse] = {
+
+    val adjustedStartDate = {
+      val sevenYearsAgo = dateTo.minusYears(7)
+      if (dateFrom.isBefore(sevenYearsAgo)) sevenYearsAgo else dateFrom
+    }
+
     financialDataConnector
-      .retrieveFinancialData(plrReference, dateFrom, dateTo)
+      .retrieveFinancialData(plrReference, adjustedStartDate, dateTo)
       .map { financialDataResponse =>
         FinancialDataResponse(
           idType = financialDataResponse.idType,
@@ -64,6 +70,7 @@ class FinancialService @Inject() (
           financialTransactions = financialDataResponse.financialTransactions
         )
       }
+  }
 
   private def getPaymentData(response: FinancialDataResponse): Seq[FinancialHistory] =
     for {

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -49,7 +49,7 @@
 
     <logger name="application" level="DEBUG"/>
 
-    <logger name="connector" level="TRACE">
+    <logger name="connector" level="TRACE" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
@@ -16,9 +16,11 @@
 
 package uk.gov.hmrc.pillar2.service
 
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
-import org.mockito.Mockito.{times, verify, when}
-import org.scalatest.concurrent.ScalaFutures
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.when
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.test.Helpers.await
 import uk.gov.hmrc.pillar2.generators.Generators
@@ -27,7 +29,8 @@ import uk.gov.hmrc.pillar2.models.FinancialDataError
 import uk.gov.hmrc.pillar2.models.financial._
 import uk.gov.hmrc.pillar2.service.FinancialServiceSpec._
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
+import java.time.LocalDateTime
 import scala.concurrent.Future
 class FinancialServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
 

--- a/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
@@ -47,15 +47,6 @@ class FinancialServiceSpec extends BaseSpec with Generators with ScalaCheckPrope
       }
     }
 
-    "return payment history when the requesting years more than one" in {
-      when(mockFinancialDataConnector.retrieveFinancialData(any(), any(), any())(any(), any())).thenReturn(Future.successful(financialDataResponse))
-
-      forAll(plrReferenceGen) { plrReference =>
-        val result = await(service.getTransactionHistory(plrReference, startDate, startDate.plusYears(3)))
-        result mustBe Right(paymentHistoryResultMultipleYears(plrReference))
-      }
-    }
-
     "return payment history when the response contains both payment and refund" in {
       when(mockFinancialDataConnector.retrieveFinancialData(any(), any(), any())(any(), any()))
         .thenReturn(Future.successful(financialResponseWithPaymentAndRefund))
@@ -86,45 +77,6 @@ class FinancialServiceSpec extends BaseSpec with Generators with ScalaCheckPrope
         }
       }
     }
-  }
-
-  "splitIntoYearIntervals" - {
-
-    "return a list of 1 year intervals between two dates" in {
-      val startDate = LocalDate.of(2020, 5, 15)
-      val endDate   = LocalDate.of(2023, 9, 10)
-      val result    = service.splitIntoYearIntervals(startDate, endDate)
-
-      val expectedResult = List(
-        Years(LocalDate.of(2020, 5, 15), LocalDate.of(2021, 5, 14)),
-        Years(LocalDate.of(2021, 5, 15), LocalDate.of(2022, 5, 14)),
-        Years(LocalDate.of(2022, 5, 15), LocalDate.of(2023, 5, 14)),
-        Years(LocalDate.of(2023, 5, 15), LocalDate.of(2023, 9, 10))
-      )
-
-      result mustBe expectedResult
-    }
-
-    "return only 1 interval if date is less than a year" in {
-      val startDate = LocalDate.of(2020, 5, 15)
-      val endDate   = LocalDate.of(2020, 9, 10)
-
-      service.splitIntoYearIntervals(startDate, endDate) mustBe List(Years(startDate, endDate))
-    }
-
-    "only return the last 7 years if dates are beyond 7 years" in {
-      val startDate = LocalDate.of(2020, 1, 1)
-      val endDate   = LocalDate.of(2028, 1, 1)
-
-      val newAdjustedStartDate = LocalDate.of(2021, 1, 1)
-
-      val result = service.splitIntoYearIntervals(startDate, endDate)
-
-      result.head.startDate mustNot be(startDate)
-      result.head.startDate mustBe newAdjustedStartDate
-      result.last.endDate mustBe endDate
-    }
-
   }
 }
 
@@ -293,19 +245,6 @@ object FinancialServiceSpec {
       plrReference,
       List(
         FinancialHistory(LocalDate.now.plusDays(2), "Refund", 0.0, 100.0),
-        FinancialHistory(LocalDate.now.plusDays(1), "Payment", 100.0, 0.00)
-      )
-    )
-
-  val paymentHistoryResultMultipleYears: String => TransactionHistory = (plrReference: String) =>
-    TransactionHistory(
-      plrReference,
-      List(
-        FinancialHistory(LocalDate.now.plusDays(2), "Refund", 0.0, 100.0),
-        FinancialHistory(LocalDate.now.plusDays(2), "Refund", 0.0, 100.0),
-        FinancialHistory(LocalDate.now.plusDays(2), "Refund", 0.0, 100.0),
-        FinancialHistory(LocalDate.now.plusDays(1), "Payment", 100.0, 0.00),
-        FinancialHistory(LocalDate.now.plusDays(1), "Payment", 100.0, 0.00),
         FinancialHistory(LocalDate.now.plusDays(1), "Payment", 100.0, 0.00)
       )
     )

--- a/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
@@ -50,12 +50,13 @@ class FinancialServiceSpec extends BaseSpec with Generators with ScalaCheckPrope
     }
 
     "return payment a not found error if no relevant history is found" in {
+      val result = FinancialDataError("NOT_FOUND", "No relevant financial data found")
       when(mockFinancialDataConnector.retrieveFinancialData(any(), any(), any())(any(), any()))
         .thenReturn(Future.successful(financialResponseWithNeitherPaymentAndRefund))
 
       forAll(plrReferenceGen) { plrReference =>
-        val result = await(service.getTransactionHistory(plrReference, startDate, endDate))
-        result mustBe Right(paymentHistoryResult(plrReference))
+        val response = await(service.getTransactionHistory(plrReference, startDate, endDate))
+        response mustBe Left(result)
       }
     }
 


### PR DESCRIPTION
**Changes Made:**

- **Single ETMP Call:** Updated `FinancialService` to make a single call to ETMP to retrieve up to 7 years of financial data, instead of making multiple yearly calls.
- **Adjusted Start Date:** Introduced logic to adjust the `dateFrom` parameter to ensure it doesn't exceed 7 years from the `dateTo` date. (This `dateTo` date, rather than strictly defaulting to today, is provided by the frontend via config [see here](https://github.com/hmrc/pillar2-frontend/blob/1c8e9a099a70b8bd583f5ac70ff2192074dd071c/conf/application.conf#L190C5-L190C38))
- **Removed Redundant Method:** Eliminated the `splitIntoYearIntervals` method since it's no longer necessary with the single-call approach.
- **Updated Tests:** Modified `FinancialServiceSpec` to reflect the new logic and ensure proper testing of the adjusted date range and single call execution.
- **Handle Empty Data Response:** Updated `FinancialService` to return a `NOT_FOUND` error when both `paymentData` and `repaymentData` are empty. This ensures that the system correctly handles cases where there are no relevant financial transactions within the requested date range.
- **Prevent Connector Duplicate Logging:** Added `additivity="false"` to the `connector` logger configuration in `conf/logback.xml` to prevent duplicate logging of connector messages.

---

**Explanation of Logging Change:**

- **Issue Addressed:** Log messages from the `connector` logger were appearing twice—once through its own appender and again through the root logger—resulting in duplicate entries in both the console and log files.
