### PR TITLE
PIL-1253 Make dateOfIncorporation optional on CompanyProfile

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/registration/IncorporatedEntityRegistrationData.scala
+++ b/app/uk/gov/hmrc/pillar2/models/registration/IncorporatedEntityRegistrationData.scala
@@ -37,7 +37,7 @@ object IncorporatedEntityRegistrationData {
 final case class CompanyProfile(
   companyName:            String,
   companyNumber:          String,
-  dateOfIncorporation:    LocalDate,
+  dateOfIncorporation:    Option[LocalDate],
   unsanitisedCHROAddress: IncorporatedEntityAddress
 )
 

--- a/test/uk/gov/hmrc/pillar2/generators/ModelGenerators.scala
+++ b/test/uk/gov/hmrc/pillar2/generators/ModelGenerators.scala
@@ -558,7 +558,7 @@ trait ModelGenerators {
     for {
       companyName            <- arbitrary[String]
       companyNumber          <- arbitrary[String]
-      dateOfIncorporation    <- arbitrary[LocalDate]
+      dateOfIncorporation    <- Gen.option(arbitrary[LocalDate])
       unsanitisedCHROAddress <- arbitrary[IncorporatedEntityAddress]
 
     } yield CompanyProfile(


### PR DESCRIPTION
Updated CompanyProfile to make dateOfIncorporation an Option[LocalDate] more than anything to just keep the model consistent with the frontend after the change [here](https://github.com/hmrc/pillar2-frontend/pull/396)