### PR TITLE
PIL-1423: Create BTN endpoint and connector

### DIFF
--- a/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.connectors
+
+import com.google.inject.Inject
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.pillar2.config.AppConfig
+import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class BTNConnector @Inject() (val config: AppConfig, val http: HttpClient)(implicit ec: ExecutionContext) {
+
+  def sendBtn(btnRequst: BTNRequest, plrReference: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    val serviceName = "below-threshold-notification"
+    http.POST[BTNRequest, HttpResponse](
+      config.baseUrl(serviceName),
+      btnRequst,
+      hipHeaders(pillar2Id = plrReference, config = config, serviceName = serviceName)
+    )
+  }
+}

--- a/app/uk/gov/hmrc/pillar2/controllers/BTNController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/BTNController.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.controllers
+
+import play.api.Logging
+import play.api.libs.json.Json
+import play.api.mvc.{Action, ControllerComponents}
+import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, Pillar2HeaderAction}
+import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.service.BTNService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class BTNController @Inject() (
+  btnService:                BTNService,
+  authenticate:              AuthAction,
+  pillar2HeaderExists:       Pillar2HeaderAction,
+  cc:                        ControllerComponents
+)(implicit executionContext: ExecutionContext)
+    extends BackendController(cc)
+    with Logging {
+
+  def submitBtn: Action[BTNRequest] = (authenticate andThen pillar2HeaderExists).async(parse.json[BTNRequest]) { implicit request =>
+    btnService
+      .sendBtn(request.body, request.pillar2Id)
+      .map(response => Ok(Json.toJson(response)))
+  }
+}

--- a/app/uk/gov/hmrc/pillar2/models/btn/BTNRequest.scala
+++ b/app/uk/gov/hmrc/pillar2/models/btn/BTNRequest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.models.btn
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+
+case class BTNRequest(accountingPeriodFrom: LocalDate, accountingPeriodTo: LocalDate)
+
+object BTNRequest {
+  implicit val format: OFormat[BTNRequest] = Json.format[BTNRequest]
+}

--- a/app/uk/gov/hmrc/pillar2/service/BTNService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/BTNService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.service
+
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2.connectors.BTNConnector
+import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.models.hip.ApiSuccessResponse
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class BTNService @Inject() (
+  btnConnector: BTNConnector
+)(implicit ec:  ExecutionContext) {
+
+  def sendBtn(btnRequest: BTNRequest, pillar2Id: String)(implicit hc: HeaderCarrier): Future[ApiSuccessResponse] =
+    btnConnector
+      .sendBtn(btnRequest, pillar2Id)
+      .flatMap(convertToApiResult)
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -28,4 +28,6 @@ GET           /transaction-history/:plrReference/:dateFrom/:dateTo         uk.go
 
 GET           /get-obligation/:plrReference/:dateFrom/:dateTo              uk.gov.hmrc.pillar2.controllers.ObligationController.getObligation(plrReference: String, dateFrom: String, dateTo: String)
 
+POST          /below-threshold-notification/submit                         uk.gov.hmrc.pillar2.controllers.BTNController.submitBtn()
+
 POST          /submit-uk-tax-return                                        uk.gov.hmrc.pillar2.controllers.UKTaxReturnController.submitUKTaxReturn()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -148,5 +148,14 @@ microservice {
       environment = ""
     }
 
+    below-threshold-notification {
+      host = localhost
+      port = 10052
+      protocol = http
+      context = "/RESTAdapter/plr/below-threshold-notification"
+      bearer-token = ""
+      environment = ""
+    }
+
   }
 }

--- a/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.Application
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.pillar2.generators.Generators
+import uk.gov.hmrc.pillar2.helpers.BaseSpec
+import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+
+import java.time.LocalDate
+
+class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
+
+  override lazy val app: Application = applicationBuilder()
+    .configure("microservice.services.below-threshold-notification.port" -> server.port())
+    .build()
+
+  private lazy val connector = app.injector.instanceOf[BTNConnector]
+
+  private val btnPayload =
+    BTNRequest(
+      accountingPeriodFrom = LocalDate.now(),
+      accountingPeriodTo = LocalDate.now().plusYears(1)
+    )
+
+  private val pillar2Id = "XMPLR0000000012"
+
+  private def stubResponseFor(status: Int)(implicit response: JsObject): StubMapping =
+    server.stubFor(
+      post(urlEqualTo("/RESTAdapter/plr/below-threshold-notification"))
+        .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
+        .withRequestBody(equalToJson(Json.toJson(btnPayload).toString()))
+        .willReturn(
+          aResponse()
+            .withStatus(status)
+            .withHeader("Content-Type", "application/json")
+            .withBody(response.toString())
+        )
+    )
+
+  "sendBtn" - {
+    "successfully submit a BTN request and receive Success response" in {
+      implicit val response: JsObject = Json.obj(
+        "success" -> Json.obj(
+          "processingDate"   -> "2024-03-14T09:26:17Z",
+          "formBundleNumber" -> "123456789012345",
+          "chargeReference"  -> "dummyChargeReference"
+        )
+      )
+
+      stubResponseFor(CREATED)
+
+      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+
+      result.status mustBe CREATED
+      result.json mustBe response
+    }
+
+    "handle BAD_REQUEST (400) response" in {
+      implicit val response: JsObject = Json.obj(
+        "error" -> Json.obj(
+          "code"    -> "400",
+          "message" -> "Bad Request",
+          "logId"   -> "123456789"
+        )
+      )
+
+      stubResponseFor(BAD_REQUEST)
+
+      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+      result.status mustBe BAD_REQUEST
+      result.json mustBe response
+    }
+
+    "handle UNPROCESSABLE_ENTITY (422) response" in {
+      implicit val response: JsObject = Json.obj(
+        "errors" -> Json.obj(
+          "processingDate" -> "2024-03-14T09:26:17Z",
+          "code"           -> "003",
+          "text"           -> "Request could not be processed"
+        )
+      )
+
+      stubResponseFor(UNPROCESSABLE_ENTITY)
+
+      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+      result.status mustBe UNPROCESSABLE_ENTITY
+      result.json mustBe response
+    }
+
+    "handle INTERNAL_SERVER_ERROR (500) response" in {
+      implicit val response: JsObject = Json.obj(
+        "error" -> Json.obj(
+          "code"    -> "500",
+          "message" -> "Internal Server Error",
+          "logId"   -> "123456789"
+        )
+      )
+
+      stubResponseFor(INTERNAL_SERVER_ERROR)
+
+      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+      result.status mustBe INTERNAL_SERVER_ERROR
+      result.json mustBe response
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.controllers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsJson
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.{Application, Configuration}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
+import uk.gov.hmrc.pillar2.generators.Generators
+import uk.gov.hmrc.pillar2.helpers.BaseSpec
+import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.models.errors._
+import uk.gov.hmrc.pillar2.models.hip.{ApiSuccess, ApiSuccessResponse}
+import uk.gov.hmrc.pillar2.service.BTNService
+
+import java.time.{LocalDate, ZonedDateTime}
+import scala.concurrent.Future
+
+class BTNControllerSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
+
+  val application: Application = new GuiceApplicationBuilder()
+    .configure(Configuration("metrics.enabled" -> "false", "auditing.enabled" -> false))
+    .overrides(
+      bind[BTNService].toInstance(mockBTNService),
+      bind[AuthConnector].toInstance(mockAuthConnector),
+      bind[AuthAction].to[FakeAuthAction]
+    )
+    .build()
+
+  val successResponse: ApiSuccessResponse = ApiSuccessResponse(
+    ApiSuccess(
+      processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
+      formBundleNumber = "123456789012345",
+      chargeReference = "12345678"
+    )
+  )
+
+  private val btnPayload =
+    BTNRequest(
+      accountingPeriodFrom = LocalDate.now(),
+      accountingPeriodTo = LocalDate.now().plusYears(1)
+    )
+
+  private val request: FakeRequest[AnyContentAsJson] = FakeRequest(POST, routes.BTNController.submitBtn().url)
+    .withHeaders("X-Pillar2-ID" -> "XMPLR0000000012")
+    .withJsonBody(Json.toJson(btnPayload))
+
+  "submitBtn" - {
+    "should return OK with ApiSuccessResponse when submission is successful" in {
+      when(mockBTNService.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(successResponse))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual OK
+      contentAsJson(result) mustEqual Json.toJson(successResponse)
+    }
+
+    "should return MissingHeaderError when X-Pillar2-Id header is missing" in {
+
+      val headlessRequest: FakeRequest[AnyContentAsJson] = FakeRequest(POST, routes.BTNController.submitBtn().url)
+        .withJsonBody(Json.toJson(btnPayload))
+
+      val result = intercept[MissingHeaderError](await(route(application, headlessRequest).value))
+      result mustEqual MissingHeaderError("X-Pillar2-Id")
+    }
+
+    "should return UNAUTHORIZED when authentication fails" in {
+      val unauthorizedApp = new GuiceApplicationBuilder()
+        .configure(Configuration("metrics.enabled" -> "false", "auditing.enabled" -> false))
+        .overrides(
+          bind[BTNService].toInstance(mockBTNService)
+        )
+        .build()
+
+      val request = FakeRequest(POST, routes.BTNController.submitBtn().url)
+        .withHeaders("X-Pillar2-ID" -> "XMPLR0000000012")
+        .withJsonBody(Json.toJson(btnPayload))
+
+      val result = route(unauthorizedApp, request).value
+      status(result) mustEqual UNAUTHORIZED
+    }
+
+    "should handle ValidationError from service" in {
+      when(mockBTNService.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
+
+      val result = intercept[ETMPValidationError](await(route(application, request).value))
+      result mustEqual ETMPValidationError("422", "Validation failed")
+    }
+
+    "should handle InvalidJsonError from service" in {
+      when(mockBTNService.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.failed(InvalidJsonError("Invalid JSON")))
+
+      val request = FakeRequest(POST, routes.BTNController.submitBtn().url)
+        .withHeaders("X-Pillar2-ID" -> "XMPLR0000000012")
+        .withJsonBody(Json.toJson(btnPayload))
+
+      val result = intercept[InvalidJsonError](await(route(application, request).value))
+      result mustEqual InvalidJsonError("Invalid JSON")
+
+    }
+
+    "should handle ApiInternalServerError from service" in {
+      when(mockBTNService.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.failed(ApiInternalServerError))
+
+      val request = FakeRequest(POST, routes.BTNController.submitBtn().url)
+        .withHeaders("X-Pillar2-ID" -> "XMPLR0000000012")
+        .withJsonBody(Json.toJson(btnPayload))
+
+      val result = intercept[ApiInternalServerError.type](await(route(application, request).value))
+      result mustEqual ApiInternalServerError
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2/helpers/AllMocks.scala
+++ b/test/uk/gov/hmrc/pillar2/helpers/AllMocks.scala
@@ -57,6 +57,8 @@ trait AllMocks extends MockitoSugar {
   val mockFinancialDataConnector:      FinancialDataConnector      = mock[FinancialDataConnector]
   val mockFinancialService:            FinancialService            = mock[FinancialService]
   val mockObligationConnector:         ObligationConnector         = mock[ObligationConnector]
+  val mockBTNService:                  BTNService                  = mock[BTNService]
+  val mockBTNConnector:                BTNConnector                = mock[BTNConnector]
 
   @nowarn
   override protected def beforeEach(): Unit =

--- a/test/uk/gov/hmrc/pillar2/service/BTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/BTNServiceSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.service
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json.Json
+import play.api.test.Helpers.await
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2.generators.Generators
+import uk.gov.hmrc.pillar2.helpers.BaseSpec
+import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
+import uk.gov.hmrc.pillar2.models.hip._
+
+import java.time.{LocalDate, ZonedDateTime}
+import scala.concurrent.Future
+
+class BTNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
+
+  val service = new BTNService(mockBTNConnector)
+
+  private val btnPayload =
+    BTNRequest(
+      accountingPeriodFrom = LocalDate.now(),
+      accountingPeriodTo = LocalDate.now().plusYears(1)
+    )
+
+  "sendBtn" - {
+    "should return ApiSuccessResponse for valid btnPayload (201)" in {
+      val successResponse = ApiSuccessResponse(ApiSuccess(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "123456789012345", "12345678"))
+      val httpResponse    = HttpResponse(201, Json.toJson(successResponse).toString())
+
+      when(mockBTNConnector.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(httpResponse))
+
+      val result = service.sendBtn(btnPayload, "XMPLR0000000012").futureValue
+      result mustBe successResponse
+    }
+
+    "should throw ValidationError for 422 response" in {
+      val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+      val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
+
+      when(mockBTNConnector.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(httpResponse))
+
+      val error = intercept[ETMPValidationError] {
+        await(service.sendBtn(btnPayload, "XMPLR0000000012"))
+      }
+
+      error.code mustBe "422"
+      error.message mustBe "Validation failed"
+    }
+
+    "should throw InvalidJsonError for malformed success response" in {
+      val httpResponse = HttpResponse(201, "{invalid json}")
+
+      when(mockBTNConnector.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(httpResponse))
+
+      val error = intercept[InvalidJsonError] {
+        await(service.sendBtn(btnPayload, "XMPLR0000000012"))
+      }
+      error.code mustBe "002"
+    }
+
+    "should throw ApiInternalServerError for non-201/422 responses" in {
+      val httpResponse = HttpResponse(500, "{}")
+
+      when(mockBTNConnector.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(httpResponse))
+
+      intercept[ApiInternalServerError.type] {
+        await(service.sendBtn(btnPayload, "XMPLR0000000012"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR builds on #86. Enabled BTN integration with ETMP:

- Added _/below-threshold-notification/submit_ endpoint
- Added models, connector and service for BTN
- Integration and unit tested new logic