### PR TITLE
PIL-1512: Add tests for X-Pillar2-Id

### DIFF
--- a/API Testing/auth/create-bearer-token.bru
+++ b/API Testing/auth/create-bearer-token.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Create Bearer Token
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{authUrl}}
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "confidenceLevel": 50,
+    "email": "user@test.com",
+    "credentialRole": "User",
+    "affinityGroup": "Organisation",
+    "credentialStrength": "strong",
+    "credId": "453234543adr54hy9",
+    "enrolments": [
+      {
+        "key": "HMRC-PILLAR2-ORG",
+        "identifiers": [
+          {
+            "key": "PLRID",
+            "value": {{testPlrId}}
+          }
+        ],
+        "state": "Activated"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  let authHeader = res.headers.authorization
+  let arr = authHeader.split(",")
+  let bearer = ""
+  if(arr[0].includes("Bearer"))
+    bearer = arr[0]
+  else
+    bearer = arr[1]
+  bru.setEnvVar("bearerToken",bearer)
+}

--- a/API Testing/bruno.json
+++ b/API Testing/bruno.json
@@ -1,0 +1,23 @@
+{
+  "version": "1",
+  "name": "API Testing",
+  "type": "collection",
+  "collections": [
+    {
+      "name": "Authentication",
+      "path": "auth"
+    },
+    {
+      "name": "UKTR Submissions",
+      "path": "uktr"
+    },
+    {
+      "name": "Below Threshold Notification",
+      "path": "btn"
+    }
+  ],
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/API Testing/btn/invalid-json.bru
+++ b/API Testing/btn/invalid-json.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Submit BTN - Invalid JSON
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+    invalid_json_here
+  }
+}
+
+tests {
+  test("should return 400 for invalid JSON", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain error about invalid JSON", function() {
+    expect(res.body.code).to.equal("400");
+    expect(res.body.message).to.include("Json validation error");
+  });
+} 

--- a/API Testing/btn/submit-missing-header.bru
+++ b/API Testing/btn/submit-missing-header.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Submit Below Threshold Notification - Missing Header
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+  }
+}
+
+tests {
+  test("should return 400 when X-Pillar2-Id header is missing", function() {
+    const response = res;
+    expect(response.status).to.equal(400);
+    expect(response.body.message).to.include("X-Pillar2-Id");
+  });
+}

--- a/API Testing/btn/submit.bru
+++ b/API Testing/btn/submit.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Submit Below Threshold Notification
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.chargeReference).to.not.be.undefined;
+    expect(res.body.formBundleNumber).to.not.be.undefined;
+    expect(res.body.processingDate).to.not.be.undefined;
+  });
+}

--- a/API Testing/btn/unauthorized.bru
+++ b/API Testing/btn/unauthorized.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Submit BTN - Unauthorized
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+  }
+}
+
+tests {
+  test("should return 401 when no auth token provided", function() {
+    expect(res.getStatus()).to.equal(401);
+  });
+} 

--- a/API Testing/environments/local.bru
+++ b/API Testing/environments/local.bru
@@ -1,0 +1,5 @@
+vars {
+  baseUrl: http://localhost:10051/report-pillar2-top-up-taxes
+  testPlrId: "XMPLR0123456789"
+  authUrl: http://localhost:8585/government-gateway/session/login
+}

--- a/API Testing/uktr/invalid-json.bru
+++ b/API Testing/uktr/invalid-json.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Submit UKTR - Invalid JSON
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: jsom
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true
+    invalid_json_here
+    "liabilities": {
+      "totalLiability": 10000.99
+    }
+  }
+}
+
+tests {
+  test("should return 400 for invalid JSON", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain error about invalid JSON", function() {
+    expect(res.body.code).to.equal("400");
+    expect(res.body.message).to.include("Invalid Json");
+  });
+} 

--- a/API Testing/uktr/submit-missing-header.bru
+++ b/API Testing/uktr/submit-missing-header.bru
@@ -1,0 +1,53 @@
+meta {
+  name: Submit UK Tax Return - Missing Header
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true,
+    "electionUKGAAP": true,
+    "liabilities": {
+      "electionDTTSingleMember": false,
+      "electionUTPRSingleMember": false,
+      "numberSubGroupDTT": 1,
+      "numberSubGroupUTPR": 1,
+      "totalLiability": 10000.99,
+      "totalLiabilityDTT": 5000.99,
+      "totalLiabilityIIR": 4000,
+      "totalLiabilityUTPR": 10000.99,
+      "liableEntities": [
+        {
+          "ukChargeableEntityName": "Newco PLC",
+          "idType": "CRN",
+          "idValue": "12345678",
+          "amountOwedDTT": 5000,
+          "amountOwedIIR": 3400,
+          "amountOwedUTPR": 6000.5
+        }
+      ]
+    }
+  }
+}
+
+tests {
+  test("should return 400 when X-Pillar2-Id header is missing", function() {
+    const response = res;
+    expect(response.status).to.equal(400);
+    expect(response.body.message).to.include("X-Pillar2-Id");
+  });
+}

--- a/API Testing/uktr/submit.bru
+++ b/API Testing/uktr/submit.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Submit UK Tax Return
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+  "accountingPeriodFrom": "2024-08-14",
+  "accountingPeriodTo": "2024-12-14",
+  "obligationMTT": true,
+  "electionUKGAAP": true,
+  "liabilities": {
+    "electionDTTSingleMember": false,
+    "electionUTPRSingleMember": false,
+    "numberSubGroupDTT": 1,
+    "numberSubGroupUTPR": 1,
+    "totalLiability": 10000.99,
+    "totalLiabilityDTT": 5000.99,
+    "totalLiabilityIIR": 4000,
+    "totalLiabilityUTPR": 10000.99,
+    "liableEntities": [
+      {
+        "ukChargeableEntityName": "Newco PLC",
+        "idType": "CRN",
+        "idValue": "12345678",
+        "amountOwedDTT": 5000,
+        "amountOwedIIR": 3400,
+        "amountOwedUTPR": 6000.5
+      }
+    ]
+    }
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.chargeReference).to.not.be.undefined;
+    expect(res.body.formBundleNumber).to.not.be.undefined;
+    expect(res.body.processingDate).to.not.be.undefined;
+  });
+}

--- a/API Testing/uktr/unauthorized.bru
+++ b/API Testing/uktr/unauthorized.bru
@@ -1,0 +1,51 @@
+meta {
+  name: Submit UKTR - Unauthorized
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+}
+
+body:json {
+  {
+  "accountingPeriodFrom": "2024-08-14",
+  "accountingPeriodTo": "2024-12-14",
+  "obligationMTT": true,
+  "electionUKGAAP": true,
+  "liabilities": {
+    "electionDTTSingleMember": false,
+    "electionUTPRSingleMember": false,
+    "numberSubGroupDTT": 1,
+    "numberSubGroupUTPR": 1,
+    "totalLiability": 10000.99,
+    "totalLiabilityDTT": 5000.99,
+    "totalLiabilityIIR": 4000,
+    "totalLiabilityUTPR": 10000.99,
+    "liableEntities": [
+      {
+        "ukChargeableEntityName": "Newco PLC",
+        "idType": "CRN",
+        "idValue": "12345678",
+        "amountOwedDTT": 5000,
+        "amountOwedIIR": 3400,
+        "amountOwedUTPR": 6000.5
+      }
+    ]
+    }
+  }
+}
+
+tests {
+  test("should return 401 when no auth token provided", function() {
+    expect(res.getStatus()).to.equal(401);
+  });
+} 

--- a/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
@@ -26,14 +26,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class BTNConnector @Inject() (val config: AppConfig, val http: HttpClient)(implicit ec: ExecutionContext) extends Logging {
 
-  def sendBtn(btnRequest: BTNRequest, plrReference: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+  def sendBtn(btnRequest: BTNRequest)(implicit hc: HeaderCarrier, pillar2Id: String): Future[HttpResponse] = {
     val serviceName = "below-threshold-notification"
     val url         = config.baseUrl(serviceName)
     logger.info(s"Calling $url to submit a BTN")
     http.POST[BTNRequest, HttpResponse](
       url,
       btnRequest,
-      hipHeaders(pillar2Id = plrReference, config = config, serviceName = serviceName)
+      hipHeaders(config = config, serviceName = serviceName)
     )
   }
 }

--- a/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2.connectors
 
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.pillar2.config.AppConfig
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmission
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,13 +29,13 @@ class UKTaxReturnConnector @Inject() (
 )(implicit ec: ExecutionContext) {
 
   def submitUKTaxReturn(
-    payload:     UktrSubmission
+    payload:     UKTRSubmission
   )(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     val serviceName = "submit-uk-tax-return"
     val url         = s"${config.baseUrl(serviceName)}"
 
     http
-      .POST[UktrSubmission, HttpResponse](
+      .POST[UKTRSubmission, HttpResponse](
         url,
         payload,
         hipHeaders(config = config, serviceName = serviceName)

--- a/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
@@ -29,8 +29,7 @@ class UKTaxReturnConnector @Inject() (
 )(implicit ec: ExecutionContext) {
 
   def submitUKTaxReturn(
-    payload:     UktrSubmission,
-    pillar2Id:   String
+    payload:     UktrSubmission
   )(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     val serviceName = "submit-uk-tax-return"
     val url         = s"${config.baseUrl(serviceName)}"
@@ -39,7 +38,7 @@ class UKTaxReturnConnector @Inject() (
       .POST[UktrSubmission, HttpResponse](
         url,
         payload,
-        hipHeaders(pillar2Id = pillar2Id, config = config, serviceName = serviceName)
+        hipHeaders(config = config, serviceName = serviceName)
       )
   }
 }

--- a/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
@@ -30,7 +30,7 @@ class UKTaxReturnConnector @Inject() (
 
   def submitUKTaxReturn(
     payload:     UKTRSubmission
-  )(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+  )(implicit hc: HeaderCarrier, pillar2Id: String): Future[HttpResponse] = {
     val serviceName = "submit-uk-tax-return"
     val url         = s"${config.baseUrl(serviceName)}"
 

--- a/app/uk/gov/hmrc/pillar2/controllers/BTNController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/BTNController.scala
@@ -19,12 +19,10 @@ package uk.gov.hmrc.pillar2.controllers
 import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc.{Action, ControllerComponents}
-import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, Pillar2HeaderAction}
 import uk.gov.hmrc.pillar2.models.btn.BTNRequest
 import uk.gov.hmrc.pillar2.service.BTNService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
@@ -39,10 +37,7 @@ class BTNController @Inject() (
     with Logging {
 
   def submitBtn: Action[BTNRequest] = (authenticate andThen pillar2HeaderExists).async(parse.json[BTNRequest]) { implicit request =>
-    implicit val hc: HeaderCarrier = HeaderCarrierConverter
-      .fromRequest(request)
-      .withExtraHeaders("X-Pillar2-Id" -> request.pillar2Id)
-
+    implicit val pillar2Id: String = request.pillar2Id
     btnService
       .sendBtn(request.body)
       .map(response => Created(Json.toJson(response.success)))

--- a/app/uk/gov/hmrc/pillar2/controllers/BTNController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/BTNController.scala
@@ -39,9 +39,12 @@ class BTNController @Inject() (
     with Logging {
 
   def submitBtn: Action[BTNRequest] = (authenticate andThen pillar2HeaderExists).async(parse.json[BTNRequest]) { implicit request =>
-    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request).withExtraHeaders("X-Pillar2-Id" -> request.pillar2Id)
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter
+      .fromRequest(request)
+      .withExtraHeaders("X-Pillar2-Id" -> request.pillar2Id)
+
     btnService
-      .sendBtn(request.body, request.pillar2Id)(hc)
+      .sendBtn(request.body)
       .map(response => Created(Json.toJson(response.success)))
   }
 }

--- a/app/uk/gov/hmrc/pillar2/controllers/UKTaxReturnController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/UKTaxReturnController.scala
@@ -20,7 +20,7 @@ import play.api.libs.json._
 import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, Pillar2HeaderAction}
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmission
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 import uk.gov.hmrc.pillar2.service.UKTaxReturnService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
@@ -37,7 +37,7 @@ class UKTaxReturnController @Inject() (
 )(implicit ec:         ExecutionContext)
     extends BackendController(cc) {
 
-  def submitUKTaxReturn(): Action[UktrSubmission] = (authenticate andThen pillar2HeaderExists).async(parse.json[UktrSubmission]) { implicit request =>
+  def submitUKTaxReturn(): Action[UKTRSubmission] = (authenticate andThen pillar2HeaderExists).async(parse.json[UKTRSubmission]) { implicit request =>
     implicit val hc: HeaderCarrier = HeaderCarrierConverter
       .fromRequest(request)
       .withExtraHeaders("X-Pillar2-Id" -> request.pillar2Id)

--- a/app/uk/gov/hmrc/pillar2/controllers/UKTaxReturnController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/UKTaxReturnController.scala
@@ -18,10 +18,12 @@ package uk.gov.hmrc.pillar2.controllers
 
 import play.api.libs.json._
 import play.api.mvc._
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, Pillar2HeaderAction}
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmission
 import uk.gov.hmrc.pillar2.service.UKTaxReturnService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
@@ -36,8 +38,12 @@ class UKTaxReturnController @Inject() (
     extends BackendController(cc) {
 
   def submitUKTaxReturn(): Action[UktrSubmission] = (authenticate andThen pillar2HeaderExists).async(parse.json[UktrSubmission]) { implicit request =>
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter
+      .fromRequest(request)
+      .withExtraHeaders("X-Pillar2-Id" -> request.pillar2Id)
+
     ukTaxReturnService
-      .submitUKTaxReturn(request.body, request.pillar2Id)
+      .submitUKTaxReturn(request.body)
       .map(response => Created(Json.toJson(response.success)))
   }
 }

--- a/app/uk/gov/hmrc/pillar2/controllers/UKTaxReturnController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/UKTaxReturnController.scala
@@ -18,12 +18,10 @@ package uk.gov.hmrc.pillar2.controllers
 
 import play.api.libs.json._
 import play.api.mvc._
-import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, Pillar2HeaderAction}
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 import uk.gov.hmrc.pillar2.service.UKTaxReturnService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
@@ -38,10 +36,7 @@ class UKTaxReturnController @Inject() (
     extends BackendController(cc) {
 
   def submitUKTaxReturn(): Action[UKTRSubmission] = (authenticate andThen pillar2HeaderExists).async(parse.json[UKTRSubmission]) { implicit request =>
-    implicit val hc: HeaderCarrier = HeaderCarrierConverter
-      .fromRequest(request)
-      .withExtraHeaders("X-Pillar2-Id" -> request.pillar2Id)
-
+    implicit val pillar2Id: String = request.pillar2Id
     ukTaxReturnService
       .submitUKTaxReturn(request.body)
       .map(response => Created(Json.toJson(response.success)))

--- a/app/uk/gov/hmrc/pillar2/models/hip/uktrsubmissions/UKTRSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/uktrsubmissions/UKTRSubmission.scala
@@ -20,7 +20,7 @@ import play.api.libs.json._
 
 import java.time.LocalDate
 
-trait UktrSubmission {
+trait UKTRSubmission {
   val accountingPeriodFrom: LocalDate
   val accountingPeriodTo:   LocalDate
   val obligationMTT:        Boolean
@@ -28,19 +28,19 @@ trait UktrSubmission {
   val liabilities:          Liability
 }
 
-object UktrSubmission {
-  implicit val uktrSubmissionReads: Reads[UktrSubmission] = (json: JsValue) =>
+object UKTRSubmission {
+  implicit val uktrSubmissionReads: Reads[UKTRSubmission] = (json: JsValue) =>
     if ((json \ "liabilities" \ "returnType").isEmpty) {
-      json.validate[UktrSubmissionData]
+      json.validate[UKTRSubmissionData]
     } else {
-      json.validate[UktrSubmissionNilReturn]
+      json.validate[UKTRSubmissionNilReturn]
     }
 
-  implicit val uktrSubmissionWrites: Writes[UktrSubmission] = new Writes[UktrSubmission] {
-    def writes(submission: UktrSubmission): JsValue = submission match {
-      case data:      UktrSubmissionData      => Json.toJson(data)(Json.writes[UktrSubmissionData])
-      case nilReturn: UktrSubmissionNilReturn => Json.toJson(nilReturn)(Json.writes[UktrSubmissionNilReturn])
-      case _ => throw new IllegalArgumentException("Unknown UktrSubmission type")
+  implicit val uktrSubmissionWrites: Writes[UKTRSubmission] = new Writes[UKTRSubmission] {
+    def writes(submission: UKTRSubmission): JsValue = submission match {
+      case data:      UKTRSubmissionData      => Json.toJson(data)(Json.writes[UKTRSubmissionData])
+      case nilReturn: UKTRSubmissionNilReturn => Json.toJson(nilReturn)(Json.writes[UKTRSubmissionNilReturn])
+      case _ => throw new IllegalArgumentException("Unknown UKTRSubmission type")
     }
   }
 }

--- a/app/uk/gov/hmrc/pillar2/models/hip/uktrsubmissions/UKTRSubmissionData.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/uktrsubmissions/UKTRSubmissionData.scala
@@ -20,14 +20,14 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.LocalDate
 
-case class UktrSubmissionNilReturn(
+case class UKTRSubmissionData(
   accountingPeriodFrom: LocalDate,
   accountingPeriodTo:   LocalDate,
   obligationMTT:        Boolean,
   electionUKGAAP:       Boolean,
-  liabilities:          LiabilityNilReturn
-) extends UktrSubmission
+  liabilities:          LiabilityData
+) extends UKTRSubmission
 
-object UktrSubmissionNilReturn {
-  implicit val uktrSubmissionNilReturnFormat: OFormat[UktrSubmissionNilReturn] = Json.format[UktrSubmissionNilReturn]
+object UKTRSubmissionData {
+  implicit val uktrSubmissionDataFormat: OFormat[UKTRSubmissionData] = Json.format[UKTRSubmissionData]
 }

--- a/app/uk/gov/hmrc/pillar2/models/hip/uktrsubmissions/UKTRSubmissionNilReturn.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/uktrsubmissions/UKTRSubmissionNilReturn.scala
@@ -20,14 +20,14 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.LocalDate
 
-case class UktrSubmissionData(
+case class UKTRSubmissionNilReturn(
   accountingPeriodFrom: LocalDate,
   accountingPeriodTo:   LocalDate,
   obligationMTT:        Boolean,
   electionUKGAAP:       Boolean,
-  liabilities:          LiabilityData
-) extends UktrSubmission
+  liabilities:          LiabilityNilReturn
+) extends UKTRSubmission
 
-object UktrSubmissionData {
-  implicit val uktrSubmissionDataFormat: OFormat[UktrSubmissionData] = Json.format[UktrSubmissionData]
+object UKTRSubmissionNilReturn {
+  implicit val uktrSubmissionNilReturnFormat: OFormat[UKTRSubmissionNilReturn] = Json.format[UKTRSubmissionNilReturn]
 }

--- a/app/uk/gov/hmrc/pillar2/service/BTNService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/BTNService.scala
@@ -29,8 +29,8 @@ class BTNService @Inject() (
   btnConnector: BTNConnector
 )(implicit ec:  ExecutionContext) {
 
-  def sendBtn(btnRequest: BTNRequest, pillar2Id: String)(implicit hc: HeaderCarrier): Future[ApiSuccessResponse] =
+  def sendBtn(btnRequest: BTNRequest)(implicit hc: HeaderCarrier): Future[ApiSuccessResponse] =
     btnConnector
-      .sendBtn(btnRequest, pillar2Id)
+      .sendBtn(btnRequest)
       .flatMap(convertToApiResult)
 }

--- a/app/uk/gov/hmrc/pillar2/service/BTNService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/BTNService.scala
@@ -29,7 +29,7 @@ class BTNService @Inject() (
   btnConnector: BTNConnector
 )(implicit ec:  ExecutionContext) {
 
-  def sendBtn(btnRequest: BTNRequest)(implicit hc: HeaderCarrier): Future[ApiSuccessResponse] =
+  def sendBtn(btnRequest: BTNRequest)(implicit hc: HeaderCarrier, pillar2Id: String): Future[ApiSuccessResponse] =
     btnConnector
       .sendBtn(btnRequest)
       .flatMap(convertToApiResult)

--- a/app/uk/gov/hmrc/pillar2/service/UKTaxReturnService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/UKTaxReturnService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2.service
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.connectors.UKTaxReturnConnector
 import uk.gov.hmrc.pillar2.models.hip.ApiSuccessResponse
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmission
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -30,7 +30,7 @@ class UKTaxReturnService @Inject() (
 )(implicit ec:          ExecutionContext) {
 
   def submitUKTaxReturn(
-    payload:     UktrSubmission
+    payload:     UKTRSubmission
   )(implicit hc: HeaderCarrier): Future[ApiSuccessResponse] =
     ukTaxReturnConnector
       .submitUKTaxReturn(payload)

--- a/app/uk/gov/hmrc/pillar2/service/UKTaxReturnService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/UKTaxReturnService.scala
@@ -30,10 +30,9 @@ class UKTaxReturnService @Inject() (
 )(implicit ec:          ExecutionContext) {
 
   def submitUKTaxReturn(
-    payload:     UktrSubmission,
-    pillar2Id:   String
+    payload:     UktrSubmission
   )(implicit hc: HeaderCarrier): Future[ApiSuccessResponse] =
     ukTaxReturnConnector
-      .submitUKTaxReturn(payload, pillar2Id)
+      .submitUKTaxReturn(payload)
       .flatMap(convertToApiResult)
 }

--- a/app/uk/gov/hmrc/pillar2/service/UKTaxReturnService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/UKTaxReturnService.scala
@@ -31,7 +31,7 @@ class UKTaxReturnService @Inject() (
 
   def submitUKTaxReturn(
     payload:     UKTRSubmission
-  )(implicit hc: HeaderCarrier): Future[ApiSuccessResponse] =
+  )(implicit hc: HeaderCarrier, pillar2Id: String): Future[ApiSuccessResponse] =
     ukTaxReturnConnector
       .submitUKTaxReturn(payload)
       .flatMap(convertToApiResult)

--- a/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
@@ -24,7 +24,6 @@ import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.btn.BTNRequest
-import uk.gov.hmrc.pillar2.models.errors.MissingHeaderError
 
 import java.time.LocalDate
 
@@ -67,7 +66,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(CREATED)
 
-      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload).futureValue
 
       result.status mustBe CREATED
       result.json mustBe response
@@ -76,12 +75,6 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
           .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
           .withRequestBody(equalToJson(Json.toJson(btnPayload).toString()))
       )
-    }
-
-    "should return MissingHeaderError when X-Pillar2-Id header is missing" in {
-      val result = intercept[MissingHeaderError](connector.sendBtn(btnPayload).futureValue)
-
-      result mustEqual MissingHeaderError("X-Pillar2-Id")
     }
 
     "handle BAD_REQUEST (400) response" in {
@@ -95,7 +88,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(BAD_REQUEST)
 
-      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload).futureValue
       result.status mustBe BAD_REQUEST
       result.json mustBe response
     }
@@ -111,7 +104,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(UNPROCESSABLE_ENTITY)
 
-      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload).futureValue
       result.status mustBe UNPROCESSABLE_ENTITY
       result.json mustBe response
     }
@@ -127,7 +120,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(INTERNAL_SERVER_ERROR)
 
-      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload).futureValue
       result.status mustBe INTERNAL_SERVER_ERROR
       result.json mustBe response
     }

--- a/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
@@ -24,6 +24,7 @@ import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.models.errors.MissingHeaderError
 
 import java.time.LocalDate
 
@@ -75,6 +76,12 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
           .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
           .withRequestBody(equalToJson(Json.toJson(btnPayload).toString()))
       )
+    }
+
+    "should return MissingHeaderError when X-Pillar2-Id header is missing" in {
+      val result = intercept[MissingHeaderError](connector.sendBtn(btnPayload).futureValue)
+
+      result mustEqual MissingHeaderError("X-Pillar2-Id")
     }
 
     "handle BAD_REQUEST (400) response" in {

--- a/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
@@ -41,8 +41,6 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
       accountingPeriodTo = LocalDate.now().plusYears(1)
     )
 
-  private val pillar2Id = "XMPLR0000000012"
-
   private def stubResponseFor(status: Int)(implicit response: JsObject): StubMapping =
     server.stubFor(
       post(urlEqualTo("/RESTAdapter/plr/below-threshold-notification"))
@@ -57,7 +55,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
     )
 
   "sendBtn" - {
-    "successfully submit a BTN request and receive Success response" in {
+    "successfully submit a BTN request with X-PILLAR2-Id and receive Success response" in {
       implicit val response: JsObject = Json.obj(
         "success" -> Json.obj(
           "processingDate"   -> "2024-03-14T09:26:17Z",
@@ -68,10 +66,15 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(CREATED)
 
-      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
 
       result.status mustBe CREATED
       result.json mustBe response
+      server.verify(
+        postRequestedFor(urlEqualTo("/RESTAdapter/plr/below-threshold-notification"))
+          .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
+          .withRequestBody(equalToJson(Json.toJson(btnPayload).toString()))
+      )
     }
 
     "handle BAD_REQUEST (400) response" in {
@@ -85,7 +88,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(BAD_REQUEST)
 
-      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
       result.status mustBe BAD_REQUEST
       result.json mustBe response
     }
@@ -101,7 +104,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(UNPROCESSABLE_ENTITY)
 
-      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
       result.status mustBe UNPROCESSABLE_ENTITY
       result.json mustBe response
     }
@@ -117,7 +120,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
 
       stubResponseFor(INTERNAL_SERVER_ERROR)
 
-      val result = connector.sendBtn(btnPayload, pillar2Id).futureValue
+      val result = connector.sendBtn(btnPayload)(hcWithPillar2Id).futureValue
       result.status mustBe INTERNAL_SERVER_ERROR
       result.json mustBe response
     }

--- a/it/test/uk/gov/hmrc/pillar2/connectors/SubscriptionConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/SubscriptionConnectorSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.pillar2.connectors
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, urlEqualTo}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
@@ -29,7 +30,7 @@ import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.{ETMPAmendSubscriptionSuccess, SubscriptionResponse}
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
 
-class SubscriptionConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
+class SubscriptionConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks with IntegrationPatience {
   override lazy val app: Application = applicationBuilder()
     .configure(
       "microservice.services.create-subscription.port" -> server.port()

--- a/it/test/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnectorSpec.scala
@@ -23,7 +23,6 @@ import play.api.Application
 import play.api.libs.json.Json
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.errors.MissingHeaderError
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.{LiabilityNilReturn, ReturnType, UKTRSubmissionNilReturn}
 
 import java.time.LocalDate
@@ -74,7 +73,7 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
           )
       )
 
-      val result = connector.submitUKTaxReturn(submissionPayload)(hcWithPillar2Id).futureValue
+      val result = connector.submitUKTaxReturn(submissionPayload).futureValue
 
       result.status mustBe CREATED
       result.json mustBe successResponse
@@ -83,12 +82,6 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
           .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
           .withRequestBody(equalToJson(Json.toJson(submissionPayload).toString()))
       )
-    }
-
-    "should return MissingHeaderError when X-Pillar2-Id header is missing" in {
-      val result = intercept[MissingHeaderError](connector.submitUKTaxReturn(submissionPayload).futureValue)
-
-      result mustEqual MissingHeaderError("X-Pillar2-Id")
     }
 
     "handle BAD_REQUEST (400) response" in {
@@ -112,7 +105,7 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
           )
       )
 
-      val result = connector.submitUKTaxReturn(submissionPayload)(hcWithPillar2Id).futureValue
+      val result = connector.submitUKTaxReturn(submissionPayload).futureValue
       result.status mustBe BAD_REQUEST
       result.json mustBe errorResponse
     }
@@ -138,7 +131,7 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
           )
       )
 
-      val result = connector.submitUKTaxReturn(submissionPayload)(hcWithPillar2Id).futureValue
+      val result = connector.submitUKTaxReturn(submissionPayload).futureValue
       result.status mustBe UNPROCESSABLE_ENTITY
       result.json mustBe errorResponse
     }
@@ -164,7 +157,7 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
           )
       )
 
-      val result = connector.submitUKTaxReturn(submissionPayload)(hcWithPillar2Id).futureValue
+      val result = connector.submitUKTaxReturn(submissionPayload).futureValue
       result.status mustBe INTERNAL_SERVER_ERROR
       result.json mustBe errorResponse
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.22.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.5")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.2.2")

--- a/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
@@ -30,15 +30,16 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
-import uk.gov.hmrc.pillar2.helpers.BaseSpec
+import uk.gov.hmrc.pillar2.helpers.{BaseSpec, UKTaxReturnDataFixture}
 import uk.gov.hmrc.pillar2.models.btn.BTNRequest
 import uk.gov.hmrc.pillar2.models.errors._
+import uk.gov.hmrc.pillar2.models.hip.{ApiSuccess, ApiSuccessResponse}
 import uk.gov.hmrc.pillar2.service.BTNService
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 import scala.concurrent.Future
 
-class BTNControllerSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
+class BTNControllerSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks with UKTaxReturnDataFixture {
 
   val application: Application = new GuiceApplicationBuilder()
     .configure(Configuration("metrics.enabled" -> "false", "auditing.enabled" -> false))
@@ -60,9 +61,6 @@ class BTNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
     .withJsonBody(Json.toJson(btnPayload))
 
   "submitBtn" - {
-    "should return OK with ApiSuccessResponse when submission is successful" in {
-      when(mockBTNService.sendBtn(any[BTNRequest])(any[HeaderCarrier], any[String]))
-      when(mockBTNService.sendBtn(any[BTNRequest])(any[HeaderCarrier]))
     "should return Created with ApiSuccessResponse when submission is successful" in {
       val successResponse: ApiSuccessResponse = ApiSuccessResponse(
         ApiSuccess(
@@ -72,8 +70,7 @@ class BTNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
         )
       )
 
-      when(mockBTNService.sendBtn(any[BTNRequest], any[String])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(successResponse))
+      when(mockBTNService.sendBtn(any[BTNRequest])(any[HeaderCarrier], any[String])).thenReturn(Future.successful(successResponse))
 
       val result = route(application, request).value
 

--- a/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.pillar2.controllers
 
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalacheck.Arbitrary.arbitrary
@@ -51,28 +50,9 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
 
   "UKTaxReturnController" - {
     "submitUKTaxReturn" - {
-      "forward the X-Pillar2-Id header" in {
-        forAll(arbitrary[UKTRSubmission]) { submission =>
-          val captor = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(captor.capture()))
-            .thenReturn(Future.successful(successResponse))
-
-          val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
-            .withHeaders("X-Pillar2-Id" -> pillar2Id)
-            .withJsonBody(Json.toJson(submission))
-
-          val result = route(application, request).value
-
-          status(result) mustEqual CREATED
-          contentAsJson(result) mustEqual Json.toJson(successResponse.success)
-          captor.getValue.extraHeaders.map(_._1) must contain("X-Pillar2-Id")
-          captor.getValue.extraHeaders.map(_._2).head mustEqual pillar2Id
-        }
-      }
-
       "should return Created with ApiSuccessResponse when submission is successful" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
             .thenReturn(Future.successful(successResponse))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
@@ -120,7 +100,7 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
 
       "should handle ValidationError from service" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
             .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
@@ -134,7 +114,7 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
 
       "should handle InvalidJsonError from service" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
             .thenReturn(Future.failed(InvalidJsonError("Invalid JSON")))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
@@ -148,7 +128,7 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
 
       "should handle ApiInternalServerError from service" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
             .thenReturn(Future.failed(ApiInternalServerError))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)

--- a/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.errors._
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmission
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 import uk.gov.hmrc.pillar2.service.UKTaxReturnService
 
 import scala.concurrent.Future
@@ -52,9 +52,9 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
   "UKTaxReturnController" - {
     "submitUKTaxReturn" - {
       "forward the X-Pillar2-Id header" in {
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           val captor = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UktrSubmission])(captor.capture()))
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(captor.capture()))
             .thenReturn(Future.successful(successResponse))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
@@ -71,8 +71,8 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       }
 
       "should return Created with ApiSuccessResponse when submission is successful" in {
-        forAll(arbitrary[UktrSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        forAll(arbitrary[UKTRSubmission]) { submission =>
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
             .thenReturn(Future.successful(successResponse))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
@@ -87,7 +87,7 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       }
 
       "should return MissingHeaderError when X-Pillar2-Id header is missing" in {
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
             .withJsonBody(Json.toJson(submission))
 
@@ -106,7 +106,7 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
           )
           .build()
 
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withJsonBody(Json.toJson(submission))
@@ -119,8 +119,8 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       //Everything after this is perhaps useless
 
       "should handle ValidationError from service" in {
-        forAll(arbitrary[UktrSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        forAll(arbitrary[UKTRSubmission]) { submission =>
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
             .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
@@ -133,8 +133,8 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       }
 
       "should handle InvalidJsonError from service" in {
-        forAll(arbitrary[UktrSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        forAll(arbitrary[UKTRSubmission]) { submission =>
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
             .thenReturn(Future.failed(InvalidJsonError("Invalid JSON")))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
@@ -147,8 +147,8 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       }
 
       "should handle ApiInternalServerError from service" in {
-        forAll(arbitrary[UktrSubmission]) { submission =>
-          when(mockUKTaxReturnService.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        forAll(arbitrary[UKTRSubmission]) { submission =>
+          when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
             .thenReturn(Future.failed(ApiInternalServerError))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)

--- a/test/uk/gov/hmrc/pillar2/generators/ModelGenerators.scala
+++ b/test/uk/gov/hmrc/pillar2/generators/ModelGenerators.scala
@@ -25,9 +25,9 @@ import uk.gov.hmrc.pillar2.models.grs._
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.LiabilityData
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.LiabilityNilReturn
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.ReturnType
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmission
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmissionData
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmissionNilReturn
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmissionData
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmissionNilReturn
 import uk.gov.hmrc.pillar2.models.hods._
 import uk.gov.hmrc.pillar2.models.hods.repayment.common.{BankDetails, RepaymentContactDetails, RepaymentDetails}
 import uk.gov.hmrc.pillar2.models.hods.repayment.request.RepaymentRequestDetail
@@ -1119,17 +1119,17 @@ trait ModelGenerators {
 
   }
 
-  implicit val arbitraryUktrSubmission: Arbitrary[UktrSubmission] = Arbitrary {
+  implicit val arbitraryUktrSubmission: Arbitrary[UKTRSubmission] = Arbitrary {
     Gen.oneOf(arbitraryUktrSubmissionNilReturn.arbitrary, arbitraryUktrSubmissionData.arbitrary)
   }
 
-  implicit val arbitraryUktrSubmissionNilReturn: Arbitrary[UktrSubmissionNilReturn] = Arbitrary {
+  implicit val arbitraryUktrSubmissionNilReturn: Arbitrary[UKTRSubmissionNilReturn] = Arbitrary {
     for {
       accountingPeriodFrom <- arbitrary[LocalDate]
       obligationMTT        <- arbitrary[Boolean]
       electionUKGAAP       <- arbitrary[Boolean]
       liabilities          <- arbitrary[LiabilityNilReturn]
-    } yield UktrSubmissionNilReturn(
+    } yield UKTRSubmissionNilReturn(
       accountingPeriodFrom = accountingPeriodFrom,
       accountingPeriodTo = accountingPeriodFrom.plusYears(1),
       obligationMTT = obligationMTT,
@@ -1138,13 +1138,13 @@ trait ModelGenerators {
     )
   }
 
-  implicit val arbitraryUktrSubmissionData: Arbitrary[UktrSubmissionData] = Arbitrary {
+  implicit val arbitraryUktrSubmissionData: Arbitrary[UKTRSubmissionData] = Arbitrary {
     for {
       accountingPeriodFrom <- arbitrary[LocalDate]
       obligationMTT        <- arbitrary[Boolean]
       electionUKGAAP       <- arbitrary[Boolean]
       liabilities          <- arbitrary[LiabilityData]
-    } yield UktrSubmissionData(
+    } yield UKTRSubmissionData(
       accountingPeriodFrom = accountingPeriodFrom,
       accountingPeriodTo = accountingPeriodFrom.plusYears(1),
       obligationMTT = obligationMTT,

--- a/test/uk/gov/hmrc/pillar2/helpers/BaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/helpers/BaseSpec.scala
@@ -56,7 +56,6 @@ trait BaseSpec
 
   implicit lazy val ec:           ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   implicit lazy val hc:           HeaderCarrier    = HeaderCarrier()
-  lazy val hcWithPillar2Id:       HeaderCarrier    = hc.withExtraHeaders("X-Pillar2-Id" -> pillar2Id)
   implicit lazy val system:       ActorSystem      = ActorSystem()
   implicit lazy val materializer: Materializer     = Materializer(system)
   val contentType:                (String, String) = "Content-Type" -> "application/json"

--- a/test/uk/gov/hmrc/pillar2/helpers/BaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/helpers/BaseSpec.scala
@@ -51,10 +51,12 @@ trait BaseSpec
     with OptionValues
     with Configs
     with Status
-    with WireMockServerHandler {
+    with WireMockServerHandler
+    with UKTaxReturnDataFixture {
 
   implicit lazy val ec:           ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   implicit lazy val hc:           HeaderCarrier    = HeaderCarrier()
+  lazy val hcWithPillar2Id:       HeaderCarrier    = hc.withExtraHeaders("X-Pillar2-Id" -> pillar2Id)
   implicit lazy val system:       ActorSystem      = ActorSystem()
   implicit lazy val materializer: Materializer     = Materializer(system)
   val contentType:                (String, String) = "Content-Type" -> "application/json"

--- a/test/uk/gov/hmrc/pillar2/helpers/UKTaxReturnDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2/helpers/UKTaxReturnDataFixture.scala
@@ -25,7 +25,7 @@ import java.time.ZonedDateTime
 
 trait UKTaxReturnDataFixture {
 
-  val pillar2Id = "XMPLR0000000012"
+  implicit val pillar2Id: String = "XMPLR0000000012"
   val successResponse: ApiSuccessResponse = ApiSuccessResponse(
     ApiSuccess(
       processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),

--- a/test/uk/gov/hmrc/pillar2/helpers/UKTaxReturnDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2/helpers/UKTaxReturnDataFixture.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.helpers
+
+import play.api.http.Status.CREATED
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.pillar2.models.hip.{ApiSuccess, ApiSuccessResponse}
+
+import java.time.ZonedDateTime
+
+trait UKTaxReturnDataFixture {
+
+  val pillar2Id = "XMPLR0000000012"
+  val successResponse: ApiSuccessResponse = ApiSuccessResponse(
+    ApiSuccess(
+      processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
+      formBundleNumber = "123456789012345",
+      chargeReference = "12345678"
+    )
+  )
+  val httpCreated: HttpResponse = HttpResponse(CREATED, Json.toJson(successResponse).toString())
+
+}

--- a/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
@@ -19,9 +19,8 @@ package uk.gov.hmrc.pillar2.service
 import org.apache.pekko.Done
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
-import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.{JsObject, JsValue, Json}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -31,7 +30,6 @@ import uk.gov.hmrc.pillar2.models.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.{ETMPAmendSubscriptionSuccess, SubscriptionResponse}
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
 import uk.gov.hmrc.pillar2.repositories.ReadSubscriptionCacheRepository
-import uk.gov.hmrc.pillar2.service.SubscriptionService
 import uk.gov.hmrc.play.audit.http.connector.AuditResult
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip._
-import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UktrSubmission
+import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 
 import java.time.ZonedDateTime
 import scala.concurrent.Future
@@ -42,10 +42,10 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       "forward the X-Pillar2-Id header" in {
         val captor = ArgumentCaptor.forClass(classOf[HeaderCarrier])
 
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UktrSubmission])(captor.capture()))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(captor.capture()))
           .thenReturn(Future.successful(httpCreated))
 
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           val result = service.submitUKTaxReturn(submission)(hcWithPillar2Id).futureValue
           result mustBe successResponse
           captor.getValue.extraHeaders.map(_._1) must contain("X-Pillar2-Id")
@@ -54,10 +54,10 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       }
 
       "should return ApiSuccessResponse for successful submission (201)" in {
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
           .thenReturn(Future.successful(httpCreated))
 
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           val result = service.submitUKTaxReturn(submission)(hcWithPillar2Id).futureValue
           result mustBe successResponse
         }
@@ -67,10 +67,10 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
         val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
         val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
           .thenReturn(Future.successful(httpResponse))
 
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           val error = intercept[ETMPValidationError] {
             await(service.submitUKTaxReturn(submission)(hcWithPillar2Id))
           }
@@ -82,10 +82,10 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       "should throw InvalidJsonError for malformed success response" in {
         val httpResponse = HttpResponse(201, "{invalid json}")
 
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
           .thenReturn(Future.successful(httpResponse))
 
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           val error = intercept[InvalidJsonError] {
             await(service.submitUKTaxReturn(submission)(hcWithPillar2Id))
           }
@@ -96,10 +96,10 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       "should throw ApiInternalServerError for non-201/422 responses" in {
         val httpResponse = HttpResponse(500, "{}")
 
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UktrSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
           .thenReturn(Future.successful(httpResponse))
 
-        forAll(arbitrary[UktrSubmission]) { submission =>
+        forAll(arbitrary[UKTRSubmission]) { submission =>
           intercept[ApiInternalServerError.type] {
             await(service.submitUKTaxReturn(submission)(hcWithPillar2Id))
           }

--- a/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.pillar2.service
 
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalacheck.Arbitrary.arbitrary
@@ -39,26 +38,12 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
 
   "UKTaxReturnService" - {
     "submitUKTaxReturn" - {
-      "forward the X-Pillar2-Id header" in {
-        val captor = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(captor.capture()))
-          .thenReturn(Future.successful(httpCreated))
-
-        forAll(arbitrary[UKTRSubmission]) { submission =>
-          val result = service.submitUKTaxReturn(submission)(hcWithPillar2Id).futureValue
-          result mustBe successResponse
-          captor.getValue.extraHeaders.map(_._1) must contain("X-Pillar2-Id")
-          captor.getValue.extraHeaders.map(_._2).head mustEqual pillar2Id
-        }
-      }
-
       "should return ApiSuccessResponse for successful submission (201)" in {
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
           .thenReturn(Future.successful(httpCreated))
 
         forAll(arbitrary[UKTRSubmission]) { submission =>
-          val result = service.submitUKTaxReturn(submission)(hcWithPillar2Id).futureValue
+          val result = service.submitUKTaxReturn(submission).futureValue
           result mustBe successResponse
         }
       }
@@ -67,12 +52,12 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
         val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
         val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
           .thenReturn(Future.successful(httpResponse))
 
         forAll(arbitrary[UKTRSubmission]) { submission =>
           val error = intercept[ETMPValidationError] {
-            await(service.submitUKTaxReturn(submission)(hcWithPillar2Id))
+            await(service.submitUKTaxReturn(submission))
           }
           error.code mustBe "422"
           error.message mustBe "Validation failed"
@@ -82,12 +67,12 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       "should throw InvalidJsonError for malformed success response" in {
         val httpResponse = HttpResponse(201, "{invalid json}")
 
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
           .thenReturn(Future.successful(httpResponse))
 
         forAll(arbitrary[UKTRSubmission]) { submission =>
           val error = intercept[InvalidJsonError] {
-            await(service.submitUKTaxReturn(submission)(hcWithPillar2Id))
+            await(service.submitUKTaxReturn(submission))
           }
           error.code mustBe "002"
         }
@@ -96,12 +81,12 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       "should throw ApiInternalServerError for non-201/422 responses" in {
         val httpResponse = HttpResponse(500, "{}")
 
-        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier]))
+        when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
           .thenReturn(Future.successful(httpResponse))
 
         forAll(arbitrary[UKTRSubmission]) { submission =>
           intercept[ApiInternalServerError.type] {
-            await(service.submitUKTaxReturn(submission)(hcWithPillar2Id))
+            await(service.submitUKTaxReturn(submission))
           }
         }
       }


### PR DESCRIPTION
- Added "X-PILLAR2-Id" to HeaderCarrier (extraHeaders) rather than pass it inline between layers (now consistent with submission-api)
- Added tests to check forwarding of the "X-PILLAR2-Id" header between layers