### PR TITLE
PIL-1512 Add Bruno scripts for BTN and UKTR submission and test missing header

### DIFF
--- a/API Testing/auth/create-bearer-token.bru
+++ b/API Testing/auth/create-bearer-token.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Create Bearer Token
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{authUrl}}
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "confidenceLevel": 50,
+    "email": "user@test.com",
+    "credentialRole": "User",
+    "affinityGroup": "Organisation",
+    "credentialStrength": "strong",
+    "credId": "453234543adr54hy9",
+    "enrolments": [
+      {
+        "key": "HMRC-PILLAR2-ORG",
+        "identifiers": [
+          {
+            "key": "PLRID",
+            "value": {{testPlrId}}
+          }
+        ],
+        "state": "Activated"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  let authHeader = res.headers.authorization
+  let arr = authHeader.split(",")
+  let bearer = ""
+  if(arr[0].includes("Bearer"))
+    bearer = arr[0]
+  else
+    bearer = arr[1]
+  bru.setEnvVar("bearerToken",bearer)
+}

--- a/API Testing/bruno.json
+++ b/API Testing/bruno.json
@@ -1,0 +1,23 @@
+{
+  "version": "1",
+  "name": "API Testing",
+  "type": "collection",
+  "collections": [
+    {
+      "name": "Authentication",
+      "path": "auth"
+    },
+    {
+      "name": "UKTR Submissions",
+      "path": "uktr"
+    },
+    {
+      "name": "Below Threshold Notification",
+      "path": "btn"
+    }
+  ],
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/API Testing/btn/invalid-json.bru
+++ b/API Testing/btn/invalid-json.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Submit BTN - Invalid JSON
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+    invalid_json_here
+  }
+}
+
+tests {
+  test("should return 400 for invalid JSON", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain error about invalid JSON", function() {
+    expect(res.body.code).to.equal("400");
+    expect(res.body.message).to.include("Invalid Json");
+  });
+} 

--- a/API Testing/btn/invalid-json.bru
+++ b/API Testing/btn/invalid-json.bru
@@ -31,6 +31,6 @@ tests {
   
   test("should contain error about invalid JSON", function() {
     expect(res.body.code).to.equal("400");
-    expect(res.body.message).to.include("Invalid Json");
+    expect(res.body.message).to.include("Json validation error");
   });
 } 

--- a/API Testing/btn/submit-missing-header.bru
+++ b/API Testing/btn/submit-missing-header.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Submit Below Threshold Notification - Missing Header
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+  }
+}
+
+tests {
+  test("should return 400 when X-Pillar2-Id header is missing", function() {
+    const response = res;
+    expect(response.status).to.equal(400);
+    expect(response.body.message).to.include("X-Pillar2-Id");
+  });
+}

--- a/API Testing/btn/submit.bru
+++ b/API Testing/btn/submit.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Submit Below Threshold Notification
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.chargeReference).to.not.be.undefined;
+    expect(res.body.formBundleNumber).to.not.be.undefined;
+    expect(res.body.processingDate).to.not.be.undefined;
+  });
+}

--- a/API Testing/btn/unauthorized.bru
+++ b/API Testing/btn/unauthorized.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Submit BTN - Unauthorized
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/below-threshold-notification/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+  }
+}
+
+tests {
+  test("should return 401 when no auth token provided", function() {
+    expect(res.getStatus()).to.equal(401);
+  });
+} 

--- a/API Testing/environments/local.bru
+++ b/API Testing/environments/local.bru
@@ -1,0 +1,5 @@
+vars {
+  baseUrl: http://localhost:10051/report-pillar2-top-up-taxes
+  testPlrId: "XMPLR0123456789"
+  authUrl: http://localhost:8585/government-gateway/session/login
+}

--- a/API Testing/uktr/invalid-json.bru
+++ b/API Testing/uktr/invalid-json.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Submit UKTR - Invalid JSON
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: jsom
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true
+    invalid_json_here
+    "liabilities": {
+      "totalLiability": 10000.99
+    }
+  }
+}
+
+tests {
+  test("should return 400 for invalid JSON", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain error about invalid JSON", function() {
+    expect(res.body.code).to.equal("400");
+    expect(res.body.message).to.include("Invalid Json");
+  });
+} 

--- a/API Testing/uktr/submit-missing-header.bru
+++ b/API Testing/uktr/submit-missing-header.bru
@@ -1,0 +1,53 @@
+meta {
+  name: Submit UK Tax Return - Missing Header
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true,
+    "electionUKGAAP": true,
+    "liabilities": {
+      "electionDTTSingleMember": false,
+      "electionUTPRSingleMember": false,
+      "numberSubGroupDTT": 1,
+      "numberSubGroupUTPR": 1,
+      "totalLiability": 10000.99,
+      "totalLiabilityDTT": 5000.99,
+      "totalLiabilityIIR": 4000,
+      "totalLiabilityUTPR": 10000.99,
+      "liableEntities": [
+        {
+          "ukChargeableEntityName": "Newco PLC",
+          "idType": "CRN",
+          "idValue": "12345678",
+          "amountOwedDTT": 5000,
+          "amountOwedIIR": 3400,
+          "amountOwedUTPR": 6000.5
+        }
+      ]
+    }
+  }
+}
+
+tests {
+  test("should return 400 when X-Pillar2-Id header is missing", function() {
+    const response = res;
+    expect(response.status).to.equal(400);
+    expect(response.body.message).to.include("X-Pillar2-Id");
+  });
+}

--- a/API Testing/uktr/submit.bru
+++ b/API Testing/uktr/submit.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Submit UK Tax Return
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+  Authorization: {{bearerToken}}
+}
+
+body:json {
+  {
+  "accountingPeriodFrom": "2024-08-14",
+  "accountingPeriodTo": "2024-12-14",
+  "obligationMTT": true,
+  "electionUKGAAP": true,
+  "liabilities": {
+    "electionDTTSingleMember": false,
+    "electionUTPRSingleMember": false,
+    "numberSubGroupDTT": 1,
+    "numberSubGroupUTPR": 1,
+    "totalLiability": 10000.99,
+    "totalLiabilityDTT": 5000.99,
+    "totalLiabilityIIR": 4000,
+    "totalLiabilityUTPR": 10000.99,
+    "liableEntities": [
+      {
+        "ukChargeableEntityName": "Newco PLC",
+        "idType": "CRN",
+        "idValue": "12345678",
+        "amountOwedDTT": 5000,
+        "amountOwedIIR": 3400,
+        "amountOwedUTPR": 6000.5
+      }
+    ]
+    }
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.chargeReference).to.not.be.undefined;
+    expect(res.body.formBundleNumber).to.not.be.undefined;
+    expect(res.body.processingDate).to.not.be.undefined;
+  });
+}

--- a/API Testing/uktr/unauthorized.bru
+++ b/API Testing/uktr/unauthorized.bru
@@ -17,12 +17,29 @@ headers {
 
 body:json {
   {
-    "accountingPeriodFrom": "2024-08-14",
-    "accountingPeriodTo": "2024-12-14",
-    "obligationMTT": true,
-    "electionUKGAAP": true,
-    "liabilities": {
-      "totalLiability": 10000.99
+  "accountingPeriodFrom": "2024-08-14",
+  "accountingPeriodTo": "2024-12-14",
+  "obligationMTT": true,
+  "electionUKGAAP": true,
+  "liabilities": {
+    "electionDTTSingleMember": false,
+    "electionUTPRSingleMember": false,
+    "numberSubGroupDTT": 1,
+    "numberSubGroupUTPR": 1,
+    "totalLiability": 10000.99,
+    "totalLiabilityDTT": 5000.99,
+    "totalLiabilityIIR": 4000,
+    "totalLiabilityUTPR": 10000.99,
+    "liableEntities": [
+      {
+        "ukChargeableEntityName": "Newco PLC",
+        "idType": "CRN",
+        "idValue": "12345678",
+        "amountOwedDTT": 5000,
+        "amountOwedIIR": 3400,
+        "amountOwedUTPR": 6000.5
+      }
+    ]
     }
   }
 }

--- a/API Testing/uktr/unauthorized.bru
+++ b/API Testing/uktr/unauthorized.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Submit UKTR - Unauthorized
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/submit-uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{testPlrId}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true,
+    "electionUKGAAP": true,
+    "liabilities": {
+      "totalLiability": 10000.99
+    }
+  }
+}
+
+tests {
+  test("should return 401 when no auth token provided", function() {
+    expect(res.getStatus()).to.equal(401);
+  });
+} 


### PR DESCRIPTION
Added API tests using Bruno for two endpoints:
- Below Threshold Notification (BTN)
- UK Tax Return (UKTR)

Tests cover:
- Happy path (successful submissions)
- Missing X-Pillar2-Id header
- Invalid Json request
- Unauthorised

for reference these test Pass for PIL-1512:
![image](https://github.com/user-attachments/assets/d4db6371-eac4-497e-8fe3-fca3803ae780)
