### PR TITLE
PIL-1348 remove formBundleNumber & chargeReference from BTNSuccess response

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/btn/BTNSuccess.scala
+++ b/app/uk/gov/hmrc/pillar2/models/btn/BTNSuccess.scala
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2.service
+package uk.gov.hmrc.pillar2.models.btn
 
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.pillar2.connectors.BTNConnector
-import uk.gov.hmrc.pillar2.models.btn.{BTNRequest, BTNSuccessResponse}
+import play.api.libs.json.{Json, OFormat}
 
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import java.time.ZonedDateTime
 
-@Singleton
-class BTNService @Inject() (
-  btnConnector: BTNConnector
-)(implicit ec:  ExecutionContext) {
+case class BTNSuccess(processingDate: ZonedDateTime)
 
-  def sendBtn(btnRequest: BTNRequest)(implicit hc: HeaderCarrier, pillar2Id: String): Future[BTNSuccessResponse] =
-    btnConnector
-      .sendBtn(btnRequest)
-      .flatMap(convertToBTNApiResult)
+object BTNSuccess {
+  implicit val format: OFormat[BTNSuccess] = Json.format[BTNSuccess]
 }

--- a/app/uk/gov/hmrc/pillar2/models/btn/BTNSuccessResponse.scala
+++ b/app/uk/gov/hmrc/pillar2/models/btn/BTNSuccessResponse.scala
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2.service
+package uk.gov.hmrc.pillar2.models.btn
 
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.pillar2.connectors.BTNConnector
-import uk.gov.hmrc.pillar2.models.btn.{BTNRequest, BTNSuccessResponse}
+import play.api.libs.json.{Json, OFormat}
 
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+case class BTNSuccessResponse(success: BTNSuccess)
 
-@Singleton
-class BTNService @Inject() (
-  btnConnector: BTNConnector
-)(implicit ec:  ExecutionContext) {
-
-  def sendBtn(btnRequest: BTNRequest)(implicit hc: HeaderCarrier, pillar2Id: String): Future[BTNSuccessResponse] =
-    btnConnector
-      .sendBtn(btnRequest)
-      .flatMap(convertToBTNApiResult)
+object BTNSuccessResponse {
+  implicit val format: OFormat[BTNSuccessResponse] = Json.format[BTNSuccessResponse]
 }

--- a/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
@@ -31,9 +31,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.{BaseSpec, UKTaxReturnDataFixture}
-import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.models.btn.{BTNRequest, BTNSuccess, BTNSuccessResponse}
 import uk.gov.hmrc.pillar2.models.errors._
-import uk.gov.hmrc.pillar2.models.hip.{ApiSuccess, ApiSuccessResponse}
 import uk.gov.hmrc.pillar2.service.BTNService
 
 import java.time.{LocalDate, ZonedDateTime}
@@ -62,12 +61,8 @@ class BTNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
 
   "submitBtn" - {
     "should return Created with ApiSuccessResponse when submission is successful" in {
-      val successResponse: ApiSuccessResponse = ApiSuccessResponse(
-        ApiSuccess(
-          processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
-          formBundleNumber = "123456789012345",
-          chargeReference = "12345678"
-        )
+      val successResponse: BTNSuccessResponse = BTNSuccessResponse(
+        BTNSuccess(processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"))
       )
 
       when(mockBTNService.sendBtn(any[BTNRequest])(any[HeaderCarrier], any[String])).thenReturn(Future.successful(successResponse))

--- a/test/uk/gov/hmrc/pillar2/service/BTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/BTNServiceSpec.scala
@@ -24,7 +24,7 @@ import play.api.test.Helpers.await
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.models.btn.{BTNRequest, BTNSuccess, BTNSuccessResponse}
 import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip._
 
@@ -43,6 +43,7 @@ class BTNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
 
   "sendBtn" - {
     "should return ApiSuccessResponse for valid btnPayload (201)" in {
+      val successResponse = BTNSuccessResponse(BTNSuccess(ZonedDateTime.parse("2024-03-14T09:26:17Z")))
       when(mockBTNConnector.sendBtn(any[BTNRequest])(any[HeaderCarrier], any[String]))
         .thenReturn(Future.successful(httpCreated))
 


### PR DESCRIPTION
PIL-1348 Align BTN submit response with EPID1519 "successResponseExample".

Remove formBundleNumber & chargeReference from BTNSuccess response, 
to Align the stub for BTN submit with EPID1519 : 

      "successResponseExample": {
        "summary": "Example of successful response",
        "description": "Example of successful response",
        "value": {
          "success": {
            "processingDate": "2022-01-31T09:26:17Z"
          }
        }

