### PR TITLE
PIL - 1681 : Unauthorised response needed for Pillar2

### DIFF
--- a/app/uk/gov/hmrc/pillar2/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/actions/AuthAction.scala
@@ -17,11 +17,10 @@
 package uk.gov.hmrc.pillar2.controllers.actions
 
 import com.google.inject.{ImplementedBy, Inject}
-import play.api.http.Status.UNAUTHORIZED
-import play.api.mvc.Results.Status
 import play.api.mvc._
-import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisedFunctions, NoActiveSession}
+import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, AuthorisedFunctions}
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2.models.errors.AuthorizationError
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -41,8 +40,8 @@ class AuthActionImpl @Inject() (
 
     authorised() {
       block(request)
-    } recover { case _: NoActiveSession =>
-      Status(UNAUTHORIZED)
+    } recoverWith { case _: AuthorisationException =>
+      Future.failed(AuthorizationError)
     }
   }
 

--- a/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
@@ -42,6 +42,11 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case error: ETMPValidationError => UnprocessableEntity(Json.toJson(Pillar2ApiError(error.code, error.message)))
           case error: InvalidJsonError    => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
           case error @ ApiInternalServerError => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
+          case error @ ObligationsAndSubmissionsError =>
+            InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
+          case error @ DateParseError     => BadRequest(Json.toJson(Pillar2ApiError(error.code, error.message)))
+          case error @ AuthorizationError => Unauthorized(Json.toJson(Pillar2ApiError(error.code, error.message)))
+
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)
         Future.successful(ret)

--- a/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
@@ -42,10 +42,7 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case error: ETMPValidationError => UnprocessableEntity(Json.toJson(Pillar2ApiError(error.code, error.message)))
           case error: InvalidJsonError    => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
           case error @ ApiInternalServerError => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
-          case error @ ObligationsAndSubmissionsError =>
-            InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
-          case error @ DateParseError     => BadRequest(Json.toJson(Pillar2ApiError(error.code, error.message)))
-          case error @ AuthorizationError => Unauthorized(Json.toJson(Pillar2ApiError(error.code, error.message)))
+          case error @ AuthorizationError     => Unauthorized(Json.toJson(Pillar2ApiError(error.code, error.message)))
 
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -42,16 +42,6 @@ case class ETMPValidationError(validationErrorCode: String, validationError: Str
   val message: String = validationError
 }
 
-case object ObligationsAndSubmissionsError extends Pillar2Error {
-  val message: String = "Internal server error"
-  val code:    String = "500"
-}
-
-case object DateParseError extends Pillar2Error {
-  val message: String = "Bad request. Invalid date format. Expected format: YYYY-MM-DD"
-  val code:    String = "400"
-}
-
 case object AuthorizationError extends Pillar2Error {
   val message: String = "Not Authorized"
   val code:    String = "401"

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -41,3 +41,18 @@ case class ETMPValidationError(validationErrorCode: String, validationError: Str
   val code:    String = validationErrorCode
   val message: String = validationError
 }
+
+case object ObligationsAndSubmissionsError extends Pillar2Error {
+  val message: String = "Internal server error"
+  val code:    String = "500"
+}
+
+case object DateParseError extends Pillar2Error {
+  val message: String = "Bad request. Invalid date format. Expected format: YYYY-MM-DD"
+  val code:    String = "400"
+}
+
+case object AuthorizationError extends Pillar2Error {
+  val message: String = "Not Authorized"
+  val code:    String = "401"
+}

--- a/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
@@ -82,14 +82,14 @@ class BTNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
       result mustEqual MissingHeaderError("X-Pillar2-Id")
     }
 
-    "should return UNAUTHORIZED when authentication fails" in {
+    "should return AuthorizationError when authentication fails" in {
       val unauthorizedApp = new GuiceApplicationBuilder()
         .configure(Configuration("metrics.enabled" -> "false", "auditing.enabled" -> false))
         .overrides(bind[BTNService].toInstance(mockBTNService))
         .build()
 
-      val result = route(unauthorizedApp, request).value
-      status(result) mustEqual UNAUTHORIZED
+      val result = intercept[AuthorizationError.type](await(route(unauthorizedApp, request).value))
+      result mustEqual AuthorizationError
     }
 
     "should handle ValidationError from service" in {

--- a/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
@@ -91,8 +91,8 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withJsonBody(Json.toJson(submission))
 
-          val result = route(unauthorizedApp, request).value
-          status(result) mustEqual UNAUTHORIZED
+          val result = intercept[AuthorizationError.type](await(route(unauthorizedApp, request).value))
+          result mustEqual AuthorizationError
         }
       }
 
@@ -167,7 +167,7 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
         }
       }
 
-      "should return UNAUTHORIZED when authentication fails" in {
+      "should return AuthorizationError when authentication fails" in {
         val unauthorizedApp = new GuiceApplicationBuilder()
           .configure(Configuration("metrics.enabled" -> "false", "auditing.enabled" -> false))
           .overrides(
@@ -180,8 +180,8 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withJsonBody(Json.toJson(submission))
 
-          val result = route(unauthorizedApp, request).value
-          status(result) mustEqual UNAUTHORIZED
+          val result = intercept[AuthorizationError.type](await(route(unauthorizedApp, request).value))
+          result mustEqual AuthorizationError
         }
       }
 

--- a/test/uk/gov/hmrc/pillar2/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/actions/AuthActionSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.http.Status.{OK, UNAUTHORIZED}
+import play.api.http.Status.OK
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{Action, AnyContent, InjectedController}
@@ -33,7 +33,7 @@ import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.auth.core.{AuthConnector, MissingBearerToken}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.pillar2.controllers.actions.AuthAction
+import uk.gov.hmrc.pillar2.models.errors.AuthorizationError
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -61,7 +61,7 @@ class AuthActionSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar
 
   "Auth Action" when {
     "the user is not logged in" must {
-      "must return unauthorised" in {
+      "must return AuthorizationError" in {
         when(
           mockAuthConnector.authorise(any[Predicate](), any[Retrieval[_]]())(
             any[HeaderCarrier](),
@@ -73,8 +73,9 @@ class AuthActionSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar
         val authAction = application.injector.instanceOf[AuthAction]
         val controller = new Harness(authAction)
         val result     = controller.onPageLoad()(FakeRequest("", ""))
-        status(result) mustBe UNAUTHORIZED
 
+        val response = intercept[AuthorizationError.type](result.value.get.get)
+        response mustEqual AuthorizationError
       }
     }
 

--- a/test/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandlerSpec.scala
@@ -81,4 +81,29 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     result.code mustEqual "003"
     result.message mustEqual "Internal server error"
   }
+
+  test("ObligationsAndSubmissionsError error response") {
+    val response = classUnderTest.onServerError(dummyRequest, ObligationsAndSubmissionsError)
+    status(response) mustEqual 500
+    val result = contentAsJson(response).as[Pillar2ApiError]
+    result.code mustEqual "500"
+    result.message mustEqual "Internal server error"
+  }
+
+  test("DateParseError error response") {
+    val response = classUnderTest.onServerError(dummyRequest, DateParseError)
+    status(response) mustEqual 400
+    val result = contentAsJson(response).as[Pillar2ApiError]
+    result.code mustEqual "400"
+    result.message mustEqual "Bad request. Invalid date format. Expected format: YYYY-MM-DD"
+  }
+
+  test("AuthorizationError error response") {
+    val response = classUnderTest.onServerError(dummyRequest, AuthorizationError)
+    status(response) mustEqual 401
+    val result = contentAsJson(response).as[Pillar2ApiError]
+    result.code mustEqual "401"
+    result.message mustEqual "Not Authorized"
+  }
+
 }

--- a/test/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandlerSpec.scala
@@ -82,22 +82,6 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     result.message mustEqual "Internal server error"
   }
 
-  test("ObligationsAndSubmissionsError error response") {
-    val response = classUnderTest.onServerError(dummyRequest, ObligationsAndSubmissionsError)
-    status(response) mustEqual 500
-    val result = contentAsJson(response).as[Pillar2ApiError]
-    result.code mustEqual "500"
-    result.message mustEqual "Internal server error"
-  }
-
-  test("DateParseError error response") {
-    val response = classUnderTest.onServerError(dummyRequest, DateParseError)
-    status(response) mustEqual 400
-    val result = contentAsJson(response).as[Pillar2ApiError]
-    result.code mustEqual "400"
-    result.message mustEqual "Bad request. Invalid date format. Expected format: YYYY-MM-DD"
-  }
-
   test("AuthorizationError error response") {
     val response = classUnderTest.onServerError(dummyRequest, AuthorizationError)
     status(response) mustEqual 401


### PR DESCRIPTION
Authorization Error has been created and added to the error handler and now the failures related to authorization will return Authorization Error messages.

**Sample API Response**
![image](https://github.com/user-attachments/assets/340272d1-be21-48fb-9fee-0bf393daa970)
