### PR TITLE
PIL-1770: Submit/Amend UKTR - optional chargeReference

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/hip/ApiSuccess.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/ApiSuccess.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.ZonedDateTime
 
-case class ApiSuccess(processingDate: ZonedDateTime, formBundleNumber: String, chargeReference: String)
+case class ApiSuccess(processingDate: ZonedDateTime, formBundleNumber: String, chargeReference: Option[String])
 
 object ApiSuccess {
   implicit val format: OFormat[ApiSuccess] = Json.format[ApiSuccess]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.6")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.2.2")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.2")

--- a/test/uk/gov/hmrc/pillar2/helpers/UKTaxReturnDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2/helpers/UKTaxReturnDataFixture.scala
@@ -30,7 +30,7 @@ trait UKTaxReturnDataFixture {
     ApiSuccess(
       processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
       formBundleNumber = "123456789012345",
-      chargeReference = "12345678"
+      chargeReference = Some("12345678")
     )
   )
   val httpCreated: HttpResponse = HttpResponse(CREATED, Json.toJson(successResponse).toString())


### PR DESCRIPTION
Make response field `chargeReference` optional to accommodate both _Liability_ and _Nil_ returns.