### PR TITLE
PIL-1832: Change X-Receipt-Date header format

### DIFF
--- a/app/uk/gov/hmrc/pillar2/connectors/package.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/package.scala
@@ -19,14 +19,14 @@ package uk.gov.hmrc.pillar2
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.pillar2.config.AppConfig
 
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 package object connectors {
 
-  implicit val httpReads: HttpReads[HttpResponse] =
-    (_: String, _: String, response: HttpResponse) => response
+  implicit val httpReads: HttpReads[HttpResponse] = (_: String, _: String, response: HttpResponse) => response
 
   private[connectors] def hipHeaders(config: AppConfig, serviceName: String)(implicit
     headerCarrier:                           HeaderCarrier,
@@ -39,7 +39,7 @@ package object connectors {
       "correlationid"         -> UUID.randomUUID().toString,
       "X-Originating-System"  -> "MDTP",
       "X-Pillar2-Id"          -> pillar2Id,
-      "X-Receipt-Date"        -> ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT),
+      "X-Receipt-Date"        -> ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).toString,
       "X-Transmitting-System" -> "HIP"
     ) ++ authHeader.headers(Seq(HeaderNames.authorisation))
   }

--- a/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/BTNConnectorSpec.scala
@@ -41,6 +41,8 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
       accountingPeriodTo = LocalDate.now().plusYears(1)
     )
 
+  private val etmpBTNUrl: String = "/RESTAdapter/plr/below-threshold-notification"
+
   private def stubResponseFor(status: Int)(implicit response: JsObject): StubMapping =
     server.stubFor(
       post(urlEqualTo("/RESTAdapter/plr/below-threshold-notification"))
@@ -55,10 +57,10 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
     )
 
   "sendBtn" - {
-    "successfully submit a BTN request with X-PILLAR2-Id and receive Success response" in {
+    "successfully submit a BTN request with all required HIP headers" in {
       implicit val response: JsObject = Json.obj(
         "success" -> Json.obj(
-          "processingDate"   -> "2024-03-14T09:26:17Z"
+          "processingDate" -> "2024-03-14T09:26:17Z"
         )
       )
 
@@ -73,6 +75,7 @@ class BTNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
           .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
           .withRequestBody(equalToJson(Json.toJson(btnPayload).toString()))
       )
+      verifyHipHeaders("POST", etmpBTNUrl, Some(Json.toJson(btnPayload).toString()))
     }
 
     "handle BAD_REQUEST (400) response" in {

--- a/it/test/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnectorSpec.scala
@@ -81,7 +81,7 @@ class ObligationsAndSubmissionsConnectorSpec extends BaseSpec with Generators wi
     )
   )
 
-  "must return status as OK when obligations and submissions data is returned" in {
+  "must return status as OK when obligations when a successful request with all required HIP headers is submitted" in {
     server.stubFor(
       get(urlEqualTo(url))
         .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
@@ -95,6 +95,7 @@ class ObligationsAndSubmissionsConnectorSpec extends BaseSpec with Generators wi
     val result = connector.getObligationsAndSubmissions(fromDate, toDate).futureValue
 
     result.status mustBe 200
+    verifyHipHeaders("GET", url)
   }
 
   "must return status as 500 when obligations and submissions data is not returned" in {

--- a/it/test/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnectorSpec.scala
@@ -33,7 +33,7 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
     applicationBuilder()
       .configure(
         "microservice.services.submit-uk-tax-return.port" -> server.port(),
-        "microservice.services.amend-uk-tax-return.port" -> server.port()
+        "microservice.services.amend-uk-tax-return.port"  -> server.port()
       )
       .build()
 
@@ -51,23 +51,6 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
   )
 
   private val etmpUKTRUrl = "/RESTAdapter/plr/uk-tax-return"
-
-  private def verifyHipHeaders(method: String, expectedBody: String): Unit = {
-    val requestBuilder = method match {
-      case "POST" => postRequestedFor(urlEqualTo(etmpUKTRUrl))
-      case "PUT"  => putRequestedFor(urlEqualTo(etmpUKTRUrl))
-    }
-
-    server.verify(
-      requestBuilder
-        .withHeader("correlationid", matching("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"))
-        .withHeader("X-Originating-System", equalTo("MDTP"))
-        .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
-        .withHeader("X-Receipt-Date", matching("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?Z"))
-        .withHeader("X-Transmitting-System", equalTo("HIP"))
-        .withRequestBody(equalToJson(expectedBody))
-    )
-  }
 
   "UKTaxReturnConnector" - {
     "submit UK tax return" - {
@@ -94,7 +77,7 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
 
         result.status mustBe CREATED
         result.json mustBe successResponse
-        verifyHipHeaders("POST", Json.toJson(submissionPayload).toString())
+        verifyHipHeaders("POST", etmpUKTRUrl, Some(Json.toJson(submissionPayload).toString()))
       }
 
       "handle BAD_REQUEST (400) response" in {
@@ -199,7 +182,7 @@ class UKTaxReturnConnectorSpec extends BaseSpec with Generators with ScalaCheckP
         val result = connector.amendUKTaxReturn(submissionPayload).futureValue
         result.status mustBe OK
         result.json mustBe successResponse
-        verifyHipHeaders("PUT", Json.toJson(submissionPayload).toString())
+        verifyHipHeaders("PUT", etmpUKTRUrl, Some(Json.toJson(submissionPayload).toString()))
       }
 
       "handle BAD_REQUEST (400) response" in {


### PR DESCRIPTION
### Changes
- Changing the header to be of time zone _UTC_ with the following format: `yyyy-MM-ddTHH:mm:ssZ`
- Adds unit tests to confirm in HIP APIs