### PR TITLE
PIL - 1633: Retrieve ORN backend 

### DIFF
--- a/app/uk/gov/hmrc/pillar2/connectors/ORNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/ORNConnector.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.pillar2.config.AppConfig
 import uk.gov.hmrc.pillar2.models.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.orn.ORNRequest
 
+import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
 class ORNConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(implicit ec: ExecutionContext) extends Logging {
@@ -36,6 +37,21 @@ class ORNConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(imp
     http
       .post(url"$url")
       .withBody(Json.toJson(ornRequest))
+      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .execute[HttpResponse]
+      .recoverWith { case _ => Future.failed(UnexpectedResponse) }
+  }
+
+  def getOrn(fromDate: LocalDate, toDate: LocalDate)(implicit
+    hc:                HeaderCarrier,
+    ec:                ExecutionContext,
+    pillar2Id:         String
+  ): Future[HttpResponse] = {
+    val serviceName = "overseas-return-notification"
+    val url =
+      s"${config.baseUrl(serviceName)}?accountingPeriodFrom=${fromDate.toString}&accountingPeriodTo=${toDate.toString}"
+    http
+      .get(url"$url")
       .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
       .execute[HttpResponse]
       .recoverWith { case _ => Future.failed(UnexpectedResponse) }

--- a/app/uk/gov/hmrc/pillar2/controllers/ORNController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/ORNController.scala
@@ -18,12 +18,13 @@ package uk.gov.hmrc.pillar2.controllers
 
 import play.api.Logging
 import play.api.libs.json.Json
-import play.api.mvc.{Action, ControllerComponents}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, Pillar2HeaderAction}
 import uk.gov.hmrc.pillar2.models.orn.ORNRequest
 import uk.gov.hmrc.pillar2.service.ORNService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import java.time.LocalDate
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
@@ -41,6 +42,13 @@ class ORNController @Inject() (
     ornService
       .submitOrn(request.body)
       .map(response => Created(Json.toJson(response.success)))
+  }
+
+  def getOrn(fromDate: String, toDate: String): Action[AnyContent] = (authenticate andThen pillar2HeaderExists).async { implicit request =>
+    implicit val pillar2Id: String = request.pillar2Id
+    ornService
+      .getOrn(LocalDate.parse(fromDate), LocalDate.parse(toDate))
+      .map(data => Ok(Json.toJson(data.success)))
   }
 
 }

--- a/app/uk/gov/hmrc/pillar2/models/orn/GetORNSuccess.scala
+++ b/app/uk/gov/hmrc/pillar2/models/orn/GetORNSuccess.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.models.orn
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.{LocalDate, ZonedDateTime}
+
+case class GetORNSuccess(
+  accountingPeriodFrom: LocalDate,
+  accountingPeriodTo:   LocalDate,
+  filedDateGIR:         LocalDate,
+  countryGIR:           String,
+  reportingEntityName:  String,
+  TIN:                  String,
+  issuingCountryTIN:    String,
+  processingDate:       ZonedDateTime
+)
+
+object GetORNSuccess {
+  implicit val format: OFormat[GetORNSuccess] = Json.format[GetORNSuccess]
+}

--- a/app/uk/gov/hmrc/pillar2/models/orn/GetORNSuccessResponse.scala
+++ b/app/uk/gov/hmrc/pillar2/models/orn/GetORNSuccessResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.models.orn
+
+import play.api.libs.json.{Json, OFormat}
+
+case class GetORNSuccessResponse(success: GetORNSuccess)
+
+object GetORNSuccessResponse {
+  implicit val format: OFormat[GetORNSuccessResponse] = Json.format[GetORNSuccessResponse]
+}

--- a/app/uk/gov/hmrc/pillar2/service/ORNService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/ORNService.scala
@@ -18,8 +18,9 @@ package uk.gov.hmrc.pillar2.service
 
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.connectors.ORNConnector
-import uk.gov.hmrc.pillar2.models.orn.{ORNRequest, ORNSuccessResponse}
+import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccessResponse, ORNRequest, ORNSuccessResponse}
 
+import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -32,4 +33,12 @@ class ORNService @Inject() (
     ornConnector
       .submitOrn(ornRequest)
       .flatMap(convertToSubmitORNApiResult)
+
+  def getOrn(
+    fromDate:    LocalDate,
+    toDate:      LocalDate
+  )(implicit hc: HeaderCarrier, pillar2Id: String): Future[GetORNSuccessResponse] =
+    ornConnector
+      .getOrn(fromDate, toDate)
+      .flatMap(convertToGetORNApiResult)
 }

--- a/app/uk/gov/hmrc/pillar2/service/package.scala
+++ b/app/uk/gov/hmrc/pillar2/service/package.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.pillar2.models.btn.BTNSuccessResponse
 import uk.gov.hmrc.pillar2.models.errors._
 import uk.gov.hmrc.pillar2.models.hip.{ApiFailureResponse, ApiSuccessResponse}
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationsAndSubmissionsResponse
-import uk.gov.hmrc.pillar2.models.orn.ORNSuccessResponse
+import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccessResponse, ORNSuccessResponse}
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
@@ -63,4 +63,7 @@ package object service extends Logging {
 
   private[service] def convertToSubmitORNApiResult(response: HttpResponse): Future[ORNSuccessResponse] =
     convertToResult[ORNSuccessResponse](response)
+
+  private[service] def convertToGetORNApiResult(response: HttpResponse): Future[GetORNSuccessResponse] =
+    convertToResult[GetORNSuccessResponse](response)
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -35,3 +35,4 @@ PUT           /amend-uk-tax-return                                         uk.go
 GET           /obligations-and-submissions/:fromDate/:toDate               uk.gov.hmrc.pillar2.controllers.ObligationsAndSubmissionsController.getObligationsAndSubmissions(fromDate: String, toDate: String)
 
 POST          /overseas-return-notification/submit                         uk.gov.hmrc.pillar2.controllers.ORNController.submitOrn()
+GET           /overseas-return-notification/:fromDate/:toDate              uk.gov.hmrc.pillar2.controllers.ORNController.getOrn(fromDate: String, toDate: String)

--- a/it/test/uk/gov/hmrc/pillar2/connectors/ORNConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/ORNConnectorSpec.scala
@@ -21,11 +21,12 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
 import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.http.InternalServerException
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccess, GetORNSuccessResponse, ORNRequest}
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZonedDateTime}
 
 class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
 
@@ -34,6 +35,12 @@ class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
     .build()
 
   private lazy val connector = app.injector.instanceOf[ORNConnector]
+
+  val fromDate: LocalDate = LocalDate.now()
+  val toDate:   LocalDate = LocalDate.now().plusYears(1)
+
+  val url: String =
+    s"/RESTAdapter/plr/overseas-return-notification/?accountingPeriodFrom=${fromDate.toString}&accountingPeriodTo=${toDate.toString}"
 
   private val ornPayload =
     ORNRequest(
@@ -46,7 +53,20 @@ class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
       issuingCountryTIN = "US"
     )
 
-  private def stubResponseFor(status: Int)(implicit response: JsObject): StubMapping =
+  val response: GetORNSuccessResponse = GetORNSuccessResponse(
+    GetORNSuccess(
+      processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
+      accountingPeriodFrom = LocalDate.now(),
+      accountingPeriodTo = LocalDate.now().plusYears(1),
+      filedDateGIR = LocalDate.now().plusYears(1),
+      countryGIR = "US",
+      reportingEntityName = "Newco PLC",
+      TIN = "US12345678",
+      issuingCountryTIN = "US"
+    )
+  )
+
+  private def stubResponseForSubmit(status: Int)(implicit response: JsObject): StubMapping =
     server.stubFor(
       post(urlEqualTo("/RESTAdapter/plr/overseas-return-notification"))
         .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
@@ -59,6 +79,17 @@ class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
         )
     )
 
+  private def stubResponseForGet(status: Int): StubMapping =
+    server.stubFor(
+      get(urlEqualTo(url))
+        .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
+        .willReturn(
+          aResponse()
+            .withStatus(status)
+            .withBody(Json.stringify(Json.toJson(response)))
+        )
+    )
+
   "submitOrn" - {
     "successfully submit a ORN request with X-PILLAR2-Id and receive Success response" in {
       implicit val response: JsObject = Json.obj(
@@ -68,7 +99,7 @@ class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
         )
       )
 
-      stubResponseFor(CREATED)
+      stubResponseForSubmit(CREATED)
 
       val result = connector.submitOrn(ornPayload).futureValue
 
@@ -90,7 +121,7 @@ class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
         )
       )
 
-      stubResponseFor(BAD_REQUEST)
+      stubResponseForSubmit(BAD_REQUEST)
 
       val result = connector.submitOrn(ornPayload).futureValue
       result.status mustBe BAD_REQUEST
@@ -106,7 +137,7 @@ class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
         )
       )
 
-      stubResponseFor(UNPROCESSABLE_ENTITY)
+      stubResponseForSubmit(UNPROCESSABLE_ENTITY)
 
       val result = connector.submitOrn(ornPayload).futureValue
       result.status mustBe UNPROCESSABLE_ENTITY
@@ -122,11 +153,34 @@ class ORNConnectorSpec extends BaseSpec with Generators with ScalaCheckPropertyC
         )
       )
 
-      stubResponseFor(INTERNAL_SERVER_ERROR)
+      stubResponseForSubmit(INTERNAL_SERVER_ERROR)
 
       val result = connector.submitOrn(ornPayload).futureValue
       result.status mustBe INTERNAL_SERVER_ERROR
       result.json mustBe response
+    }
+  }
+
+  "getOrn" - {
+    "successfully get a ORN with X-PILLAR2-Id and receive Success response" in {
+
+      stubResponseForGet(OK)
+
+      val result = connector.getOrn(fromDate, toDate).futureValue
+
+      result.status mustBe OK
+      verifyHipHeaders("GET", url)
+    }
+
+    "must return status as 500 when ORN is not returned" in {
+
+      stubResponseForGet(INTERNAL_SERVER_ERROR)
+
+      val result = connector.getOrn(fromDate, toDate).failed
+
+      result.failed.map { ex =>
+        ex mustBe a[InternalServerException]
+      }
     }
   }
 }

--- a/it/test/uk/gov/hmrc/pillar2/controllers/ORNControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/controllers/ORNControllerIntegrationSpec.scala
@@ -29,10 +29,10 @@ import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.helpers.AuthStubs
 import uk.gov.hmrc.pillar2.helpers.wiremock.WireMockServerHandler
 import uk.gov.hmrc.pillar2.models.errors.Pillar2ApiError
-import uk.gov.hmrc.pillar2.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccess, GetORNSuccessResponse, ORNRequest}
 
-import java.net.URI
-import java.time.LocalDate
+import java.net.{URI, URL}
+import java.time.{LocalDate, ZonedDateTime}
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration.DurationInt
@@ -45,24 +45,48 @@ class ORNControllerIntegrationSpec extends AnyFunSuite with GuiceOneServerPerSui
     .configure("metrics.enabled" -> false)
     .build()
 
-  val successfulResponse =  Json.obj(
+  val successfulResponse = Json.obj(
     "success" -> Json.obj(
       "processingDate"   -> "2024-03-14T09:26:17Z",
       "formBundleNumber" -> "123456789012345"
     )
   )
 
-  val ornPayload = Json.toJson(ORNRequest(
-    accountingPeriodFrom = LocalDate.now(),
-    accountingPeriodTo = LocalDate.now().plusYears(1),
-    filedDateGIR = LocalDate.now().plusYears(1),
-    countryGIR = "US",
-    reportingEntityName = "Newco PLC",
-    TIN = "US12345678",
-    issuingCountryTIN = "US"
-  ))
+  val ornPayload = Json.toJson(
+    ORNRequest(
+      accountingPeriodFrom = LocalDate.now(),
+      accountingPeriodTo = LocalDate.now().plusYears(1),
+      filedDateGIR = LocalDate.now().plusYears(1),
+      countryGIR = "US",
+      reportingEntityName = "Newco PLC",
+      TIN = "US12345678",
+      issuingCountryTIN = "US"
+    )
+  )
 
-  lazy val url = URI.create( s"http://localhost:$port${routes.ORNController.submitOrn().url}").toURL
+  val response: GetORNSuccessResponse = GetORNSuccessResponse(
+    GetORNSuccess(
+      processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
+      accountingPeriodFrom = LocalDate.now(),
+      accountingPeriodTo = LocalDate.now().plusYears(1),
+      filedDateGIR = LocalDate.now().plusYears(1),
+      countryGIR = "US",
+      reportingEntityName = "Newco PLC",
+      TIN = "US12345678",
+      issuingCountryTIN = "US"
+    )
+  )
+
+  val fromDate: LocalDate = LocalDate.now()
+  val toDate:   LocalDate = LocalDate.now()
+
+  lazy val getUrl: URL = URI
+    .create(
+      s"http://localhost:$port${routes.ORNController.getOrn(fromDate.toString, toDate.toString).url}"
+    )
+    .toURL
+
+  lazy val submitUrl = URI.create(s"http://localhost:$port${routes.ORNController.submitOrn().url}").toURL
 
   test("Successful ORN submission") {
     stubAuthenticate()
@@ -83,9 +107,10 @@ class ORNControllerIntegrationSpec extends AnyFunSuite with GuiceOneServerPerSui
     val httpClient = app.injector.instanceOf[HttpClientV2]
     implicit val headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
       .withExtraHeaders("X-Pillar2-Id" -> pillar2Id, "Content-Type" -> "application/json")
-    val request = httpClient.post(url)
+    val request = httpClient
+      .post(submitUrl)
       .withBody(ornPayload)
-    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+    val result = Await.result(request.execute[HttpResponse], 5.seconds)
     result.status mustEqual 201
   }
 
@@ -94,13 +119,43 @@ class ORNControllerIntegrationSpec extends AnyFunSuite with GuiceOneServerPerSui
 
     val httpClient = app.injector.instanceOf[HttpClientV2]
     implicit val headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
-      .withExtraHeaders( "Content-Type" -> "application/json")
-    val request = httpClient.post(url)
+      .withExtraHeaders("Content-Type" -> "application/json")
+    val request = httpClient
+      .post(submitUrl)
       .withBody(ornPayload)
-    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+    val result = Await.result(request.execute[HttpResponse], 5.seconds)
     result.status mustEqual 400
     val error = result.json.as[Pillar2ApiError]
     error.code mustEqual "001"
     error.message mustEqual "Missing X-Pillar2-Id header"
+  }
+
+  test("Successful ORN get request") {
+    stubAuthenticate()
+    val pillar2Id = "pillar2Id"
+    server.stubFor(
+      get(
+        urlEqualTo(s"/RESTAdapter/plr/overseas-return-notification/?accountingPeriodFrom=${fromDate.toString}&accountingPeriodTo=${toDate.toString}")
+      )
+        .withHeader("correlationid", matching(".+"))
+        .withHeader("X-Transmitting-System", equalTo("HIP"))
+        .withHeader("X-Originating-System", equalTo("MDTP"))
+        .withHeader("X-Receipt-Date", matching(".+"))
+        .withHeader("X-Pillar2-Id", equalTo("pillar2Id"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(Json.stringify(Json.toJson(response)))
+        )
+    )
+
+    val httpClient = app.injector.instanceOf[HttpClientV2]
+    implicit val headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
+      .withExtraHeaders("X-Pillar2-Id" -> pillar2Id, "Content-Type" -> "application/json")
+    val request = httpClient.get(getUrl)
+    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+    result.status mustEqual 200
+    Json.parse(result.body) mustBe Json.toJson(response.success)
   }
 }

--- a/test/uk/gov/hmrc/pillar2/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/ORNControllerSpec.scala
@@ -16,13 +16,14 @@
 
 package uk.gov.hmrc.pillar2.controllers
 
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
-import play.api.mvc.AnyContentAsJson
+import play.api.mvc.{AnyContentAsEmpty, AnyContentAsJson}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Application, Configuration}
@@ -32,7 +33,7 @@ import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.errors._
-import uk.gov.hmrc.pillar2.models.orn.{ORNRequest, ORNSuccess, ORNSuccessResponse}
+import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccess, GetORNSuccessResponse, ORNRequest, ORNSuccess, ORNSuccessResponse}
 import uk.gov.hmrc.pillar2.service.ORNService
 
 import java.time.{LocalDate, ZonedDateTime}
@@ -60,9 +61,15 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
       issuingCountryTIN = "US"
     )
 
-  private val request: FakeRequest[AnyContentAsJson] = FakeRequest(POST, routes.ORNController.submitOrn().url)
+  val fromDate: LocalDate = LocalDate.now()
+  val toDate:   LocalDate = LocalDate.now().plusYears(1)
+
+  private val submitRequest: FakeRequest[AnyContentAsJson] = FakeRequest(POST, routes.ORNController.submitOrn().url)
     .withHeaders("X-Pillar2-ID" -> pillar2Id)
     .withJsonBody(Json.toJson(ornPayload))
+
+  private val getRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, routes.ORNController.getOrn(fromDate.toString, toDate.toString).url)
+    .withHeaders("X-Pillar2-ID" -> pillar2Id)
 
   "submitOrn" - {
     "should return Created with OrnSuccessResponse when submission is successful" in {
@@ -72,7 +79,7 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
 
       when(mockOrnService.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String])).thenReturn(Future.successful(successResponse))
 
-      val result = route(application, request).value
+      val result = route(application, submitRequest).value
 
       status(result) mustEqual CREATED
       contentAsJson(result) mustEqual Json.toJson(successResponse.success)
@@ -93,7 +100,7 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
         .overrides(bind[ORNService].toInstance(mockOrnService))
         .build()
 
-      val result = intercept[AuthorizationError.type](await(route(unauthorizedApp, request).value))
+      val result = intercept[AuthorizationError.type](await(route(unauthorizedApp, submitRequest).value))
       result mustEqual AuthorizationError
     }
 
@@ -101,7 +108,7 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
       when(mockOrnService.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
         .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
 
-      val result = intercept[ETMPValidationError](await(route(application, request).value))
+      val result = intercept[ETMPValidationError](await(route(application, submitRequest).value))
       result mustEqual ETMPValidationError("422", "Validation failed")
     }
 
@@ -109,14 +116,98 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
       when(mockOrnService.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
         .thenReturn(Future.failed(InvalidJsonError("Invalid JSON")))
 
-      val result = intercept[InvalidJsonError](await(route(application, request).value))
+      val result = intercept[InvalidJsonError](await(route(application, submitRequest).value))
       result mustEqual InvalidJsonError("Invalid JSON")
     }
 
     "should handle ApiInternalServerError from service" in {
       when(mockOrnService.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String])).thenReturn(Future.failed(ApiInternalServerError))
 
-      val result = intercept[ApiInternalServerError.type](await(route(application, request).value))
+      val result = intercept[ApiInternalServerError.type](await(route(application, submitRequest).value))
+      result mustEqual ApiInternalServerError
+    }
+  }
+
+  "getOrn" - {
+    "should return 200 with getOrnSuccessResponse when getOrn is successful" in {
+      val successResponse: GetORNSuccessResponse = GetORNSuccessResponse(
+        GetORNSuccess(
+          processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
+          accountingPeriodFrom = LocalDate.now(),
+          accountingPeriodTo = LocalDate.now().plusYears(1),
+          filedDateGIR = LocalDate.now().plusYears(1),
+          countryGIR = "US",
+          reportingEntityName = "Newco PLC",
+          TIN = "US12345678",
+          issuingCountryTIN = "US"
+        )
+      )
+
+      when(
+        mockOrnService.getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+          any[HeaderCarrier],
+          ArgumentMatchers.eq(pillar2Id)
+        )
+      ).thenReturn(Future.successful(successResponse))
+
+      val result = route(application, getRequest).value
+
+      status(result) mustEqual OK
+      contentAsJson(result) mustEqual Json.toJson(successResponse.success)
+
+    }
+
+    "should return MissingHeaderError when X-Pillar2-Id header is missing" in {
+
+      val headlessRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, routes.ORNController.getOrn(fromDate.toString, toDate.toString).url)
+
+      val result = intercept[MissingHeaderError](await(route(application, headlessRequest).value))
+      result mustEqual MissingHeaderError("X-Pillar2-Id")
+    }
+
+    "should return AuthorizationError when authentication fails" in {
+      val unauthorizedApp = new GuiceApplicationBuilder()
+        .configure(Configuration("metrics.enabled" -> "false", "auditing.enabled" -> false))
+        .overrides(bind[ORNService].toInstance(mockOrnService))
+        .build()
+
+      val result = intercept[AuthorizationError.type](await(route(unauthorizedApp,getRequest).value))
+      result mustEqual AuthorizationError
+    }
+
+    "should handle ValidationError from service" in {
+      when(
+        mockOrnService.getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+          any[HeaderCarrier],
+          ArgumentMatchers.eq(pillar2Id)
+        )
+      ).thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
+
+      val result = intercept[ETMPValidationError](await(route(application, getRequest).value))
+      result mustEqual ETMPValidationError("422", "Validation failed")
+    }
+
+    "should handle InvalidJsonError from service" in {
+      when(
+        mockOrnService.getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+          any[HeaderCarrier],
+          ArgumentMatchers.eq(pillar2Id)
+        )
+      ).thenReturn(Future.failed(InvalidJsonError("Invalid JSON")))
+
+      val result = intercept[InvalidJsonError](await(route(application, getRequest).value))
+      result mustEqual InvalidJsonError("Invalid JSON")
+    }
+
+    "should handle ApiInternalServerError from service" in {
+      when(
+        mockOrnService.getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+          any[HeaderCarrier],
+          ArgumentMatchers.eq(pillar2Id)
+        )
+      ).thenReturn(Future.failed(ApiInternalServerError))
+
+      val result = intercept[ApiInternalServerError.type](await(route(application, getRequest).value))
       result mustEqual ApiInternalServerError
     }
   }

--- a/test/uk/gov/hmrc/pillar2/service/ORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/ORNServiceSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.pillar2.service
 
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -26,10 +27,10 @@ import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip._
-import uk.gov.hmrc.pillar2.models.orn.{ORNRequest, ORNSuccess, ORNSuccessResponse}
+import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccess, GetORNSuccessResponse, ORNRequest, ORNSuccess, ORNSuccessResponse}
 
 import java.time.{LocalDate, ZonedDateTime}
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
 
@@ -45,6 +46,8 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
       TIN = "US12345678",
       issuingCountryTIN = "US"
     )
+  val fromDate: LocalDate = LocalDate.now()
+  val toDate:   LocalDate = LocalDate.now().plusYears(1)
 
   "submitOrn" - {
     "should return SuccessResponse for valid ornPayload (201)" in {
@@ -91,6 +94,91 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
 
       intercept[ApiInternalServerError.type] {
         await(service.submitOrn(ornPayload))
+      }
+    }
+  }
+
+  "getOrn" - {
+    "should return SuccessResponse when orn exists (201)" in {
+      val successResponse = GetORNSuccessResponse(
+        GetORNSuccess(
+          processingDate = ZonedDateTime.parse("2024-03-14T09:26:17Z"),
+          accountingPeriodFrom = LocalDate.now(),
+          accountingPeriodTo = LocalDate.now().plusYears(1),
+          filedDateGIR = LocalDate.now().plusYears(1),
+          countryGIR = "US",
+          reportingEntityName = "Newco PLC",
+          TIN = "US12345678",
+          issuingCountryTIN = "US"
+        )
+      )
+
+      when(
+        mockOrnConnector
+          .getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+            any[HeaderCarrier],
+            any[ExecutionContext],
+            ArgumentMatchers.eq(pillar2Id)
+          )
+      ).thenReturn(Future.successful(HttpResponse(OK, Json.toJson(successResponse).toString())))
+
+      val result = service.getOrn(fromDate, toDate).futureValue
+      result mustBe successResponse
+    }
+
+    "should throw ValidationError for 422 response" in {
+      val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+      val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
+
+      when(
+        mockOrnConnector
+          .getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+            any[HeaderCarrier],
+            any[ExecutionContext],
+            ArgumentMatchers.eq(pillar2Id)
+          )
+      ).thenReturn(Future.successful(httpResponse))
+
+      val error = intercept[ETMPValidationError] {
+        await(service.getOrn(fromDate, toDate))
+      }
+
+      error.code mustBe "422"
+      error.message mustBe "Validation failed"
+    }
+
+    "should throw InvalidJsonError for malformed success response" in {
+      val httpResponse = HttpResponse(201, "{invalid json}")
+
+      when(
+        mockOrnConnector
+          .getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+            any[HeaderCarrier],
+            any[ExecutionContext],
+            ArgumentMatchers.eq(pillar2Id)
+          )
+      ).thenReturn(Future.successful(httpResponse))
+
+      val error = intercept[InvalidJsonError] {
+        await(service.getOrn(fromDate, toDate))
+      }
+      error.code mustBe "002"
+    }
+
+    "should throw ApiInternalServerError for non-201/422 responses" in {
+      val httpResponse = HttpResponse(500, "{}")
+
+      when(
+        mockOrnConnector
+          .getOrn(ArgumentMatchers.eq(fromDate), ArgumentMatchers.eq(toDate))(
+            any[HeaderCarrier],
+            any[ExecutionContext],
+            ArgumentMatchers.eq(pillar2Id)
+          )
+      ).thenReturn(Future.successful(httpResponse))
+
+      intercept[ApiInternalServerError.type] {
+        await(service.getOrn(fromDate, toDate))
       }
     }
   }


### PR DESCRIPTION
**PR Summary: Implement API for Get ORN**

This implementation introduces the API model and supporting components required to retrieve the latest submitted or amended Overseas Return Notification (ORN). The key features of this PR include:

**API Model for Get ORN**: Created a case class **GetORNSuccess** that encapsulates the returned ORN payload, including:

```
accountingPeriodFrom: LocalDate
accountingPeriodTo: LocalDate
filedDateGIR: LocalDate
countryGIR: String
reportingEntityName: String
TIN: String
issuingCountryTIN: String
processingDate: ZonedDateTime
```

Updated ORN controller, service and connector to support the new endpoint:

GET /overseas-return-notification/:fromDate/:toDate

The endpoint retrieves the latest submitted or amended ORN payload within the specified accounting period.

Returns any associated error messages as part of the response.

This feature enables users to retrieve the most recent ORN submission within a specified date range, receive helpful error messages when applicable, and interact with the system through a well-defined GET endpoint.

**Sample API Response**
<img width="1105" alt="Screenshot 2025-04-17 at 09 46 01" src="https://github.com/user-attachments/assets/3b7c9d04-f3fe-4e92-bf1b-2db32bfd0447" />

