### PR TITLE
PIL-1917 Update Obligations and Submissions stub

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/ObligationType.scala
+++ b/app/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/ObligationType.scala
@@ -24,6 +24,6 @@ object ObligationType extends Enum[ObligationType] with PlayJsonEnum[ObligationT
 
   val values: IndexedSeq[ObligationType] = findValues
 
-  case object Pillar2TaxReturn extends ObligationType
-  case object GlobeInformationReturn extends ObligationType
+  case object UKTR extends ObligationType
+  case object GIR extends ObligationType
 }

--- a/app/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/SubmissionType.scala
+++ b/app/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/SubmissionType.scala
@@ -23,9 +23,10 @@ sealed trait SubmissionType extends EnumEntry
 object SubmissionType extends Enum[SubmissionType] with PlayJsonEnum[SubmissionType] {
 
   val values: IndexedSeq[SubmissionType] = findValues
-
+  case object UKTR_CREATE extends SubmissionType
+  case object UKTR_AMEND extends SubmissionType
+  case object ORN_CREATE extends SubmissionType
+  case object ORN_AMEND extends SubmissionType
   case object BTN extends SubmissionType
   case object GIR extends SubmissionType
-  case object ORN extends SubmissionType
-  case object UKTR extends SubmissionType
 }

--- a/it/test/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnectorSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.http.InternalServerException
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GlobeInformationReturn, Pillar2TaxReturn}
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.BTN
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions._
 
@@ -58,7 +58,7 @@ class ObligationsAndSubmissionsConnectorSpec extends BaseSpec with Generators wi
           underEnquiry = false,
           Seq(
             Obligation(
-              Pillar2TaxReturn,
+              UKTR,
               Fulfilled,
               canAmend = false,
               Seq(
@@ -70,7 +70,7 @@ class ObligationsAndSubmissionsConnectorSpec extends BaseSpec with Generators wi
               )
             ),
             Obligation(
-              GlobeInformationReturn,
+              GIR,
               Open,
               canAmend = true,
               Seq.empty

--- a/it/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerIntegrationSpec.scala
@@ -30,8 +30,8 @@ import uk.gov.hmrc.pillar2.helpers.AuthStubs
 import uk.gov.hmrc.pillar2.helpers.wiremock.WireMockServerHandler
 import uk.gov.hmrc.pillar2.models.errors.Pillar2ApiError
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GlobeInformationReturn, Pillar2TaxReturn}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.UKTR
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.UKTR_CREATE
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions._
 
 import java.net.{URI, URL}
@@ -59,19 +59,19 @@ class ObligationsAndSubmissionsControllerIntegrationSpec extends AnyFunSuite wit
           underEnquiry = false,
           Seq(
             Obligation(
-              Pillar2TaxReturn,
+              UKTR,
               Fulfilled,
               canAmend = false,
               Seq(
                 Submission(
-                  UKTR,
+                  UKTR_CREATE,
                   ZonedDateTime.now(),
                   None
                 )
               )
             ),
             Obligation(
-              GlobeInformationReturn,
+              GIR,
               Open,
               canAmend = true,
               Seq.empty

--- a/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -33,8 +33,8 @@ import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.errors.ApiInternalServerError
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GlobeInformationReturn, Pillar2TaxReturn}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.ORN
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.ORN_CREATE
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions._
 import uk.gov.hmrc.pillar2.service.ObligationsAndSubmissionsService
 
@@ -75,19 +75,19 @@ class ObligationsAndSubmissionsControllerSpec extends BaseSpec with Generators w
           underEnquiry = false,
           Seq(
             Obligation(
-              Pillar2TaxReturn,
+              UKTR,
               Fulfilled,
               canAmend = false,
               Seq(
                 Submission(
-                  ORN,
+                  ORN_CREATE,
                   ZonedDateTime.now(),
                   Some("Country details")
                 )
               )
             ),
             Obligation(
-              GlobeInformationReturn,
+              GIR,
               Open,
               canAmend = true,
               Seq.empty

--- a/test/uk/gov/hmrc/pillar2/service/ObligationsAndSubmissionsServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/ObligationsAndSubmissionsServiceSpec.scala
@@ -26,8 +26,8 @@ import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.errors.ApiInternalServerError
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GlobeInformationReturn, Pillar2TaxReturn}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.UKTR
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.UKTR_CREATE
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions._
 
 import java.time.{LocalDate, ZonedDateTime}
@@ -50,19 +50,19 @@ class ObligationsAndSubmissionsServiceSpec extends BaseSpec with Generators with
           underEnquiry = false,
           Seq(
             Obligation(
-              Pillar2TaxReturn,
+              UKTR,
               Fulfilled,
               canAmend = false,
               Seq(
                 Submission(
-                  UKTR,
+                  UKTR_CREATE,
                   ZonedDateTime.now,
                   None
                 )
               )
             ),
             Obligation(
-              GlobeInformationReturn,
+              GIR,
               Open,
               canAmend = true,
               Seq.empty


### PR DESCRIPTION
Updated SubmissionType and ObligationType models to support new submission formats
Removed original UKTR and ORN from SubmissionType, replaced with UKTR_CREATE, UKTR_AMEND, ORN_CREATE, and ORN_AMEND
Updated ObligationType to use UKTR and GIR
Fixed all related test files to use the new enum types
This change aligns with the stub repository implementation that assigns submission types based on HTTP method (POST/PUT)
Enables Obligations and Submissions to correctly display UKTR submissions under UKTR obligation type and ORN submissions under GIR obligation type