### PR TITLE
[PIL-2046-hip-auth] Use HIP auth for connectors

### DIFF
--- a/app/uk/gov/hmrc/pillar2/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pillar2/config/AppConfig.scala
@@ -35,6 +35,7 @@ class AppConfig @Inject() (val config: Configuration, servicesConfig: ServicesCo
   val cryptoToggle:               Boolean = config.get[Boolean]("encryptionToggle")
 
   val bearerToken:                String => String = (serviceName: String) => config.get[String](s"microservice.services.$serviceName.bearer-token")
+  lazy val hipKey:                String           = config.get[String]("hip.key")
   val environment:                String => String = (serviceName: String) => config.get[String](s"microservice.services.$serviceName.environment")
   lazy val locationCanonicalList: String           = config.get[String]("location.canonical.list.all")
 }

--- a/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
@@ -36,7 +36,7 @@ class BTNConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(imp
     http
       .post(url"$url")
       .withBody(Json.toJson(btnRequest))
-      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .setHeader(hipHeaders(config = config): _*)
       .execute[HttpResponse]
       .recoverWith { case _ => Future.failed(UnexpectedResponse) }
   }

--- a/app/uk/gov/hmrc/pillar2/connectors/ORNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/ORNConnector.scala
@@ -37,7 +37,7 @@ class ORNConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(imp
     http
       .post(url"$url")
       .withBody(Json.toJson(ornRequest))
-      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .setHeader(hipHeaders(config = config): _*)
       .execute[HttpResponse]
       .recoverWith { case _ => Future.failed(UnexpectedResponse) }
   }
@@ -47,7 +47,7 @@ class ORNConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(imp
     http
       .put(url"$url")
       .withBody(Json.toJson(ornRequest))
-      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .setHeader(hipHeaders(config = config): _*)
       .execute[HttpResponse]
       .recoverWith { case _ => Future.failed(UnexpectedResponse) }
   }
@@ -62,7 +62,7 @@ class ORNConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(imp
       s"${config.baseUrl(serviceName)}?accountingPeriodFrom=${fromDate.toString}&accountingPeriodTo=${toDate.toString}"
     http
       .get(url"$url")
-      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .setHeader(hipHeaders(config = config): _*)
       .execute[HttpResponse]
       .recoverWith { case _ => Future.failed(UnexpectedResponse) }
   }

--- a/app/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnector.scala
@@ -37,7 +37,7 @@ class ObligationsAndSubmissionsConnector @Inject() (val config: AppConfig, val h
       s"${config.baseUrl(serviceName)}/?fromDate=${fromDate.toString}&toDate=${toDate.toString}"
     httpClient
       .get(url"$url")
-      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .setHeader(hipHeaders(config = config): _*)
       .execute[HttpResponse]
       .recoverWith { case _ => Future.failed(UnexpectedResponse) }
   }

--- a/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/UKTaxReturnConnector.scala
@@ -38,7 +38,7 @@ class UKTaxReturnConnector @Inject() (
 
     http
       .post(url"$url")
-      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .setHeader(hipHeaders(config = config): _*)
       .withBody(Json.toJson(payload))
       .execute[HttpResponse]
   }
@@ -51,7 +51,7 @@ class UKTaxReturnConnector @Inject() (
 
     http
       .put(url"$url")
-      .setHeader(hipHeaders(config = config, serviceName = serviceName): _*)
+      .setHeader(hipHeaders(config = config): _*)
       .withBody(Json.toJson(payload))
       .execute[HttpResponse]
   }

--- a/app/uk/gov/hmrc/pillar2/connectors/package.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/package.scala
@@ -28,12 +28,12 @@ package object connectors {
 
   implicit val httpReads: HttpReads[HttpResponse] = (_: String, _: String, response: HttpResponse) => response
 
-  private[connectors] def hipHeaders(config: AppConfig, serviceName: String)(implicit
+  private[connectors] def hipHeaders(config: AppConfig)(implicit
     headerCarrier:                           HeaderCarrier,
     pillar2Id:                               String
   ): Seq[(String, String)] = {
     val authHeader = headerCarrier
-      .copy(authorization = Some(Authorization(s"Bearer ${config.bearerToken(serviceName)}")))
+      .copy(authorization = Some(Authorization(s"Basic ${config.hipKey}")))
 
     Seq(
       "correlationid"        -> UUID.randomUUID().toString,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -83,6 +83,7 @@ mongodb {
   }
 }
 
+hip.key = "hip-key"
 registrationCache.key = "3VtqfPHHbnHRXII0Atd7uoV7nS0tDYlnELkzU9qErXY="
 encryptionToggle = false
 

--- a/test/uk/gov/hmrc/pillar2/helpers/BaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/helpers/BaseSpec.scala
@@ -129,6 +129,7 @@ trait BaseSpec
       .withHeader("X-Pillar2-Id", equalTo(pillar2Id))
       .withHeader("X-Receipt-Date", matching("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"))
       .withHeader("X-Transmitting-System", equalTo("HIP"))
+      .withHeader("Authorization", equalTo("Basic hip-key"))
 
     val ifHasBody = expectedBody.fold(getVerification)(body => getVerification.withRequestBody(equalToJson(body)))
 


### PR DESCRIPTION
Use `Basic` auth for all connectors that use HIP and use the new config key that hold the HIP credentials