### PR TITLE
PIL 2057 - Handle Missing Submissions in Obligation Deserialisation

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/Obligation.scala
+++ b/app/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/Obligation.scala
@@ -18,10 +18,6 @@ package uk.gov.hmrc.pillar2.models.obligationsAndSubmissions
 
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json._
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.Submission
-
 final case class Obligation(
   obligationType: ObligationType,
   status:         ObligationStatus,

--- a/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -32,6 +32,8 @@ import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.errors.ApiInternalServerError
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
+import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.SubmissionType.ORN_CREATE
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions._
 import uk.gov.hmrc.pillar2.service.ObligationsAndSubmissionsService
@@ -40,8 +42,6 @@ import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZonedDateTime}
 import java.util.UUID
 import scala.concurrent.Future
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
-import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}
 
 class ObligationsAndSubmissionsControllerSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
   val application: Application = new GuiceApplicationBuilder()

--- a/test/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/ObligationsAndSubmissionsSuccessResponseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/models/obligationsAndSubmissions/ObligationsAndSubmissionsSuccessResponseSpec.scala
@@ -166,6 +166,7 @@ class ObligationsAndSubmissionsSuccessResponseSpec extends AnyFreeSpec with Matc
                 "obligationType" -> "UKTR",
                 "status"         -> "Open",
                 "canAmend"       -> true
+                // submissions field intentionally omitted
               )
             )
           )


### PR DESCRIPTION
This pull request updates the Obligation model to ensure it can be successfully decoded when the submissions array is absent from an incoming JSON payload.

Previously, the Obligation model would fail to deserialize if the submissions field was missing. This change modifies the JSON Reads for the model, using readWithDefault to treat a missing submissions field as an empty list (Seq.empty).