### PR TITLE
PIL-2232 - Add optional org name to cache

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/hods/subscription/common/ReadSubscriptionCachedData.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hods/subscription/common/ReadSubscriptionCachedData.scala
@@ -34,7 +34,8 @@ case class ReadSubscriptionCachedData(
   subSecondaryCapturePhone:    Option[String],
   subSecondaryPhonePreference: Option[Boolean],
   subRegisteredAddress:        NonUKAddress,
-  accountStatus:               Option[AccountStatus]
+  accountStatus:               Option[AccountStatus],
+  organisationName:            Option[String]
 )
 
 object ReadSubscriptionCachedData {

--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -441,6 +441,8 @@ class SubscriptionService @Inject() (
       }
       .getOrElse((None, None, None))
 
+    val organisationName: Option[String] = Some(sub.upeDetails.organisationName)
+
     ReadSubscriptionCachedData(
       plrReference = Some(plrReference),
       subMneOrDomestic = if (sub.upeDetails.domesticOnly) MneOrDomestic.Uk else MneOrDomestic.UkAndOther,
@@ -455,7 +457,8 @@ class SubscriptionService @Inject() (
       subSecondaryPhonePreference = Some(secContactTel._1),
       subRegisteredAddress = nonUKAddress,
       subAccountingPeriod = accountingPeriod,
-      accountStatus = sub.accountStatus
+      accountStatus = sub.accountStatus,
+      organisationName = organisationName
     )
   }
 


### PR DESCRIPTION
Adds `organisationName` field to `ReadSubscriptionCachedData` to support upcoming feature requirements.

**Changes:**
- Added `organisationName: Option[String]` to cached data model  
- Updated `SubscriptionService.createCachedObject()` to populate organisation name from subscription response

**Migration Strategy:**
Field is initially optional to prevent failures with existing cache entries. After 28-day TTL period, we can safely make this field mandatory as all cached entries will include the organisation name. This migration will be done as part of this ticket:
https://jira.tools.tax.service.gov.uk/browse/PIL-2232