### PR TITLE
PIL-2427 - Aggregate payment sub-items in transaction history

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/financial/FinancialTransaction.scala
+++ b/app/uk/gov/hmrc/pillar2/models/financial/FinancialTransaction.scala
@@ -26,7 +26,6 @@ final case class FinancialTransaction(
   taxPeriodFrom:     Option[LocalDate] = None,
   taxPeriodTo:       Option[LocalDate] = None,
   outstandingAmount: Option[BigDecimal] = None,
-  clearedAmount:     Option[BigDecimal] = None,
   items:             Seq[FinancialItem]
 )
 

--- a/app/uk/gov/hmrc/pillar2/models/financial/FinancialTransaction.scala
+++ b/app/uk/gov/hmrc/pillar2/models/financial/FinancialTransaction.scala
@@ -26,6 +26,7 @@ final case class FinancialTransaction(
   taxPeriodFrom:     Option[LocalDate] = None,
   taxPeriodTo:       Option[LocalDate] = None,
   outstandingAmount: Option[BigDecimal] = None,
+  clearedAmount:     Option[BigDecimal] = None,
   items:             Seq[FinancialItem]
 )
 

--- a/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
@@ -70,10 +70,10 @@ class FinancialService @Inject() (
 
   private def getPaymentData(response: FinancialDataResponse): Seq[FinancialHistory] =
     for {
-      financialData  <- response.financialTransactions.filter(_.mainTransaction.contains(PaymentIdentifier))
-      financialItems <- financialData.items
-      dueDate        <- financialItems.dueDate
-      paymentAmount  <- financialItems.paymentAmount
+      financialData <- response.financialTransactions.filter(_.mainTransaction.contains(PaymentIdentifier))
+      financialItem <- financialData.items.headOption
+      dueDate       <- financialItem.dueDate
+      paymentAmount <- financialItem.paymentAmount
     } yield FinancialHistory(date = dueDate, paymentType = Payment, amountPaid = paymentAmount.abs, amountRepaid = 0.00)
 
   private def getRepaymentData(response: FinancialDataResponse): Seq[FinancialHistory] =

--- a/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
@@ -391,18 +391,19 @@ object FinancialServiceSpec {
     taxPeriodFrom = None,
     taxPeriodTo = None,
     outstandingAmount = None,
+    clearedAmount = Some(7000),
     items = Seq(
       FinancialItem(
         dueDate = Some(LocalDate.now.minusDays(5)),
-        amount = Some(-4896.99),
-        paymentAmount = Some(7766),
+        amount = Some(-3499),
+        paymentAmount = Some(7000),
         clearingDate = Some(LocalDate.now.minusDays(5)),
         clearingReason = Some("Allocated to Charge")
       ),
       FinancialItem(
         dueDate = Some(LocalDate.now.minusDays(10)),
-        amount = Some(-4103.01),
-        paymentAmount = Some(7531),
+        amount = Some(-3501),
+        paymentAmount = Some(7000),
         clearingDate = Some(LocalDate.now.minusDays(10)),
         clearingReason = Some("Allocated to Charge")
       )

--- a/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
@@ -391,7 +391,6 @@ object FinancialServiceSpec {
     taxPeriodFrom = None,
     taxPeriodTo = None,
     outstandingAmount = None,
-    clearedAmount = Some(7000),
     items = Seq(
       FinancialItem(
         dueDate = Some(LocalDate.now.minusDays(5)),
@@ -470,9 +469,8 @@ object FinancialServiceSpec {
       plrReference,
       List(
         FinancialHistory(LocalDate.now, "Repayment interest", 0.0, 333.33),
-        FinancialHistory(LocalDate.now.minusDays(5), "Payment", 7766, 0.00),
-        FinancialHistory(LocalDate.now.minusDays(10), "Payment", 7531, 0.00),
-        FinancialHistory(LocalDate.now.minusDays(15), "Payment", 789.12, 0),
+        FinancialHistory(LocalDate.now.minusDays(5), "Payment", 7000.00, 0.00),
+        FinancialHistory(LocalDate.now.minusDays(15), "Payment", 789.12, 0.00),
         FinancialHistory(LocalDate.now.minusDays(20), "Repayment", 0.0, 456.78)
       )
     )


### PR DESCRIPTION
This PR addresses an issue on the Transaction History page where payments were being displayed multiple times. This was caused by the system creating a separate payment record for each `item` within a single payment `financialTransaction` from the Get Financial Data API.

The fix involves updating the `getPaymentData` method in `FinancialService` to only process the first `item` in the sequence for each payment transaction. This ensures that a single, aggregated payment is displayed, reflecting the total amount paid.

**Important Context**

This change is a tactical fix to address the immediate issue with duplicate payment records. Further development on this financial data processing logic is not planned, as we will soon be migrating to the new "Account activity" endpoint, which will provide a more robust source for this information.