### PR TITLE
PIL-2578 Forward error details from ETMP to error responses

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -44,7 +44,7 @@ case object AuthorizationError extends Pillar2Error {
 }
 
 object ApiInternalServerError {
-  val defaultInstance = ApiInternalServerError(
+  val defaultInstance: ApiInternalServerError = ApiInternalServerError(
     message = "Internal server error",
     code = "003"
   )

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.pillar2.models.errors
 
+import java.time.ZonedDateTime
+
 sealed trait Pillar2Error extends Exception {
   val message: String
   val code:    String
@@ -32,17 +34,18 @@ case class InvalidJsonError(decodeError: String) extends Pillar2Error {
 
 }
 
-case object ApiInternalServerError extends Pillar2Error {
-  val message: String = "Internal server error"
-  val code:    String = "003"
-}
+case class ApiInternalServerError(message: String, code: String) extends Pillar2Error
 
-case class ETMPValidationError(validationErrorCode: String, validationError: String) extends Pillar2Error {
-  val code:    String = validationErrorCode
-  val message: String = validationError
-}
+case class ETMPValidationError(code: String, message: String, processingDate: ZonedDateTime) extends Pillar2Error
 
 case object AuthorizationError extends Pillar2Error {
   val message: String = "Not Authorized"
   val code:    String = "401"
+}
+
+object ApiInternalServerError {
+  val defaultInstance = ApiInternalServerError(
+    message = "Internal server error",
+    code = "003"
+  )
 }

--- a/app/uk/gov/hmrc/pillar2/models/hip/ErrorFailure.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/ErrorFailure.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2.models.errors
+package uk.gov.hmrc.pillar2.models.hip
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Json, Reads}
 
-import java.time.ZonedDateTime
+case class ErrorFailure(code: String, message: String)
 
-case class Pillar2ApiError(code: String, message: String, processingDate: Option[ZonedDateTime])
-
-object Pillar2ApiError {
-  implicit val format: OFormat[Pillar2ApiError] = Json.format[Pillar2ApiError]
+object ErrorFailure {
+  implicit val reads: Reads[ErrorFailure] = Json.reads
 }

--- a/app/uk/gov/hmrc/pillar2/models/hip/ErrorFailureResponse.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/ErrorFailureResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.pillar2.models.hip
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Json, Reads}
 
-case class ApiFailureResponse(errors: ApiFailure)
+case class ErrorFailureResponse(error: ErrorFailure)
 
-object ApiFailureResponse {
-  implicit val format: OFormat[ApiFailureResponse] = Json.format[ApiFailureResponse]
+object ErrorFailureResponse {
+  implicit val reads: Reads[ErrorFailureResponse] = Json.reads
 }

--- a/app/uk/gov/hmrc/pillar2/models/hip/UnprocessableFailure.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/UnprocessableFailure.scala
@@ -20,8 +20,8 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.ZonedDateTime
 
-case class ApiFailure(processingDate: ZonedDateTime, code: String, text: String)
+case class UnprocessableFailure(processingDate: ZonedDateTime, code: String, text: String)
 
-object ApiFailure {
-  implicit val format: OFormat[ApiFailure] = Json.format[ApiFailure]
+object UnprocessableFailure {
+  implicit val format: OFormat[UnprocessableFailure] = Json.format[UnprocessableFailure]
 }

--- a/app/uk/gov/hmrc/pillar2/models/hip/UnprocessableFailureResponse.scala
+++ b/app/uk/gov/hmrc/pillar2/models/hip/UnprocessableFailureResponse.scala
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2.models.errors
+package uk.gov.hmrc.pillar2.models.hip
 
 import play.api.libs.json.{Json, OFormat}
 
-import java.time.ZonedDateTime
+case class UnprocessableFailureResponse(errors: UnprocessableFailure)
 
-case class Pillar2ApiError(code: String, message: String, processingDate: Option[ZonedDateTime])
-
-object Pillar2ApiError {
-  implicit val format: OFormat[Pillar2ApiError] = Json.format[Pillar2ApiError]
+object UnprocessableFailureResponse {
+  implicit val format: OFormat[UnprocessableFailureResponse] = Json.format[UnprocessableFailureResponse]
 }

--- a/test/uk/gov/hmrc/pillar2/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/ORNControllerSpec.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.pillar2.models.errors._
 import uk.gov.hmrc.pillar2.models.orn.{ORNRequest, ORNSuccess, ORNSuccessResponse}
 import uk.gov.hmrc.pillar2.service.ORNService
 
-import java.time.ZonedDateTime
+import java.time.{ZoneOffset, ZonedDateTime}
 import scala.concurrent.Future
 
 class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks with ORNDataFixture {
@@ -49,6 +49,8 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
       bind[AuthAction].to[FakeAuthAction]
     )
     .build()
+
+  private val now = ZonedDateTime.now(ZoneOffset.UTC)
 
   private val submitOrnRequest: FakeRequest[AnyContentAsJson] = FakeRequest(POST, routes.ORNController.submitOrn().url)
     .withHeaders("X-Pillar2-ID" -> pillar2Id)
@@ -97,10 +99,10 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
 
     "should handle ValidationError from service" in {
       when(mockOrnService.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
-        .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
+        .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed", now)))
 
       val result = intercept[ETMPValidationError](await(route(application, submitOrnRequest).value))
-      result mustEqual ETMPValidationError("422", "Validation failed")
+      result mustEqual ETMPValidationError("422", "Validation failed", now)
     }
 
     "should handle InvalidJsonError from service" in {
@@ -112,10 +114,11 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
     }
 
     "should handle ApiInternalServerError from service" in {
-      when(mockOrnService.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String])).thenReturn(Future.failed(ApiInternalServerError))
+      when(mockOrnService.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
+        .thenReturn(Future.failed(ApiInternalServerError("errorMessage", "errorCode")))
 
-      val result = intercept[ApiInternalServerError.type](await(route(application, submitOrnRequest).value))
-      result mustEqual ApiInternalServerError
+      val result = intercept[ApiInternalServerError](await(route(application, submitOrnRequest).value))
+      result mustEqual ApiInternalServerError("errorMessage", "errorCode")
     }
   }
 
@@ -144,10 +147,10 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
 
     "should handle ValidationError from service" in {
       when(mockOrnService.amendOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
-        .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
+        .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed", now)))
 
       val result = intercept[ETMPValidationError](await(route(application, amendOrnRequest).value))
-      result mustEqual ETMPValidationError("422", "Validation failed")
+      result mustEqual ETMPValidationError("422", "Validation failed", now)
     }
 
     "should handle InvalidJsonError from service" in {
@@ -159,10 +162,11 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
     }
 
     "should handle ApiInternalServerError from service" in {
-      when(mockOrnService.amendOrn(any[ORNRequest])(any[HeaderCarrier], any[String])).thenReturn(Future.failed(ApiInternalServerError))
+      when(mockOrnService.amendOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
+        .thenReturn(Future.failed(ApiInternalServerError("errorMessage", "errorCode")))
 
-      val result = intercept[ApiInternalServerError.type](await(route(application, amendOrnRequest).value))
-      result mustEqual ApiInternalServerError
+      val result = intercept[ApiInternalServerError](await(route(application, amendOrnRequest).value))
+      result mustEqual ApiInternalServerError("errorMessage", "errorCode")
     }
   }
 
@@ -206,10 +210,10 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
           any[HeaderCarrier],
           ArgumentMatchers.eq(pillar2Id)
         )
-      ).thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
+      ).thenReturn(Future.failed(ETMPValidationError("422", "Validation failed", now)))
 
       val result = intercept[ETMPValidationError](await(route(application, getOrnRequest).value))
-      result mustEqual ETMPValidationError("422", "Validation failed")
+      result mustEqual ETMPValidationError("422", "Validation failed", now)
     }
 
     "should handle InvalidJsonError from service" in {
@@ -230,10 +234,10 @@ class ORNControllerSpec extends BaseSpec with Generators with ScalaCheckProperty
           any[HeaderCarrier],
           ArgumentMatchers.eq(pillar2Id)
         )
-      ).thenReturn(Future.failed(ApiInternalServerError))
+      ).thenReturn(Future.failed(ApiInternalServerError("errorMessage", "errorCode")))
 
-      val result = intercept[ApiInternalServerError.type](await(route(application, getOrnRequest).value))
-      result mustEqual ApiInternalServerError
+      val result = intercept[ApiInternalServerError](await(route(application, getOrnRequest).value))
+      result mustEqual ApiInternalServerError("errorMessage", "errorCode")
     }
   }
 }

--- a/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -133,7 +133,7 @@ class ObligationsAndSubmissionsControllerSpec extends BaseSpec with Generators w
           ArgumentMatchers.eq(pillar2Id)
         )
       )
-        .thenReturn(Future.failed(ApiInternalServerError))
+        .thenReturn(Future.failed(ApiInternalServerError("errorMessage", "errorCode")))
 
       val request =
         FakeRequest(GET, routes.ObligationsAndSubmissionsController.getObligationsAndSubmissions(fromDate.toString, toDate.toString).url)
@@ -146,7 +146,7 @@ class ObligationsAndSubmissionsControllerSpec extends BaseSpec with Generators w
           )
 
       val result = route(application, request).value.failed.futureValue
-      result mustEqual ApiInternalServerError
+      result mustEqual ApiInternalServerError("errorMessage", "errorCode")
     }
   }
 

--- a/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
@@ -35,6 +35,7 @@ import uk.gov.hmrc.pillar2.models.errors._
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 import uk.gov.hmrc.pillar2.service.UKTaxReturnService
 
+import java.time.{ZoneOffset, ZonedDateTime}
 import scala.concurrent.Future
 
 class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheckPropertyChecks {
@@ -47,6 +48,8 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       bind[AuthAction].to[FakeAuthAction]
     )
     .build()
+
+  private val now = ZonedDateTime.now(ZoneOffset.UTC)
 
   "UKTaxReturnController" - {
     "submitUKTaxReturn" - {
@@ -101,14 +104,14 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       "should handle ValidationError from service" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
           when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
-            .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
+            .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed", now)))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withJsonBody(Json.toJson(submission))
 
           val result = intercept[ETMPValidationError](await(route(application, request).value))
-          result mustEqual ETMPValidationError("422", "Validation failed")
+          result mustEqual ETMPValidationError("422", "Validation failed", now)
         }
       }
 
@@ -129,14 +132,14 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       "should handle ApiInternalServerError from service" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
           when(mockUKTaxReturnService.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
-            .thenReturn(Future.failed(ApiInternalServerError))
+            .thenReturn(Future.failed(ApiInternalServerError("errorMessage", "errorCode")))
 
           val request = FakeRequest(POST, routes.UKTaxReturnController.submitUKTaxReturn().url)
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withJsonBody(Json.toJson(submission))
 
-          val result = intercept[ApiInternalServerError.type](await(route(application, request).value))
-          result mustEqual ApiInternalServerError
+          val result = intercept[ApiInternalServerError](await(route(application, request).value))
+          result mustEqual ApiInternalServerError("errorMessage", "errorCode")
         }
       }
     }
@@ -188,14 +191,14 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       "should handle ValidationError from service" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
           when(mockUKTaxReturnService.amendUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
-            .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed")))
+            .thenReturn(Future.failed(ETMPValidationError("422", "Validation failed", now)))
 
           val request = FakeRequest(PUT, routes.UKTaxReturnController.amendUKTaxReturn().url)
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withJsonBody(Json.toJson(submission))
 
           val result = intercept[ETMPValidationError](await(route(application, request).value))
-          result mustEqual ETMPValidationError("422", "Validation failed")
+          result mustEqual ETMPValidationError("422", "Validation failed", now)
         }
       }
 
@@ -216,14 +219,14 @@ class UKTaxReturnControllerSpec extends BaseSpec with Generators with ScalaCheck
       "should handle ApiInternalServerError from service" in {
         forAll(arbitrary[UKTRSubmission]) { submission =>
           when(mockUKTaxReturnService.amendUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
-            .thenReturn(Future.failed(ApiInternalServerError))
+            .thenReturn(Future.failed(ApiInternalServerError("errorMessage", "errorCode")))
 
           val request = FakeRequest(PUT, routes.UKTaxReturnController.amendUKTaxReturn().url)
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withJsonBody(Json.toJson(submission))
 
-          val result = intercept[ApiInternalServerError.type](await(route(application, request).value))
-          result mustEqual ApiInternalServerError
+          val result = intercept[ApiInternalServerError](await(route(application, request).value))
+          result mustEqual ApiInternalServerError("errorMessage", "errorCode")
         }
       }
 

--- a/test/uk/gov/hmrc/pillar2/service/BTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/BTNServiceSpec.scala
@@ -52,7 +52,7 @@ class BTNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
     }
 
     "should throw ValidationError for 422 response" in {
-      val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+      val apiFailure   = UnprocessableFailureResponse(UnprocessableFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
       val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
       when(mockBTNConnector.sendBtn(any[BTNRequest])(any[HeaderCarrier], any[String]))
@@ -84,7 +84,7 @@ class BTNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
       when(mockBTNConnector.sendBtn(any[BTNRequest])(any[HeaderCarrier], any[String]))
         .thenReturn(Future.successful(httpResponse))
 
-      intercept[ApiInternalServerError.type] {
+      intercept[ApiInternalServerError] {
         await(service.sendBtn(btnPayload))
       }
     }

--- a/test/uk/gov/hmrc/pillar2/service/GenericServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/GenericServiceSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.service
+
+import org.scalacheck.Gen
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.{Json, Reads}
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.pillar2.helpers.BaseSpec
+import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
+
+import java.time.ZonedDateTime
+
+class GenericServiceSpec extends BaseSpec with ScalaCheckDrivenPropertyChecks with ScalaFutures {
+
+  case class DummyType(someInt: Int)
+
+  object DummyType {
+    implicit val reads: Reads[DummyType] = Json.reads
+  }
+
+  "generic response mapping" - {
+
+    "when handling a 200 or 201" - {
+
+      val dummyValue        = 10
+      val dummyInstance     = DummyType(dummyValue)
+      val dummyInstanceJson = Json.obj("someInt" -> dummyValue)
+
+      val okOrCreated = Gen.oneOf(200, 201)
+
+      "with a valid JSON body" - {
+        "returns a successful future" in forAll(okOrCreated) { httpStatus =>
+          val result = convertToResult[DummyType](HttpResponse(httpStatus, dummyInstanceJson.toString()))
+          result.futureValue mustBe dummyInstance
+        }
+      }
+
+      "with an unparseable JSON body" - {
+        "fails the future with an invalid json error" in forAll(okOrCreated) { httpStatus =>
+          val result = convertToResult[DummyType](HttpResponse(httpStatus, Json.obj().toString()))
+          result.failed.futureValue mustBe an[InvalidJsonError]
+        }
+      }
+
+      "with a non-JSON body" - {
+        "fails the future" in forAll(okOrCreated) { httpStatus =>
+          val result = convertToResult[DummyType](HttpResponse(httpStatus, "not json"))
+          result.failed.futureValue mustBe an[InvalidJsonError]
+        }
+      }
+
+    }
+
+    "when handling a 422" - {
+
+      val unprocessableErrorCode      = "some test error code"
+      val unprocessableMessage        = "some fake error message"
+      val unprocessableProcessingDate = "2022-01-31T09:26:17Z"
+      val unprocessableJson = Json.obj(
+        "errors" -> Json.obj(
+          "processingDate" -> unprocessableProcessingDate,
+          "code"           -> unprocessableErrorCode,
+          "text"           -> unprocessableMessage
+        )
+      )
+      val unprocessableModelledError =
+        ETMPValidationError(unprocessableErrorCode, unprocessableMessage, ZonedDateTime.parse(unprocessableProcessingDate))
+
+      "with a valid JSON body" - {
+        "returns a failed future with a modelled error" in {
+          val result = convertToResult[DummyType](HttpResponse(422, unprocessableJson.toString()))
+          result.failed.futureValue mustBe unprocessableModelledError
+        }
+      }
+
+      "with an unparseable JSON body" - {
+        "fails the future with an invalid json error" in {
+          val result = convertToResult[DummyType](HttpResponse(422, Json.obj().toString()))
+          result.failed.futureValue mustBe InvalidJsonError(Json.obj().toString())
+        }
+      }
+
+      "with a non-JSON body" - {
+        "fails the future" in {
+          val result = convertToResult[DummyType](HttpResponse(422, "not json"))
+          result.failed.futureValue mustBe an[InvalidJsonError]
+        }
+      }
+    }
+
+    "when handling a 400 or 500" - {
+
+      val errorCode    = "some test error code"
+      val errorMessage = "some fake error message"
+      val errorJson = Json.obj(
+        "error" -> Json.obj(
+          "code"    -> errorCode,
+          "message" -> errorMessage,
+          "logID"   -> "unused"
+        )
+      )
+      val modelledError = ApiInternalServerError(errorMessage, errorCode)
+
+      val expectedErrorStatuses = Gen.oneOf(400, 500)
+
+      "with a valid JSON body" - {
+        "returns a failed future with a modelled error" in forAll(expectedErrorStatuses) { httpStatus =>
+          val result = convertToResult[DummyType](HttpResponse(httpStatus, errorJson.toString()))
+          result.failed.futureValue mustBe modelledError
+        }
+      }
+
+      "with an unparseable JSON body" - {
+        "fails the future with a default internal server error" in forAll(expectedErrorStatuses) { httpStatus =>
+          val result = convertToResult[DummyType](HttpResponse(httpStatus, Json.obj().toString()))
+          result.failed.futureValue mustBe ApiInternalServerError.defaultInstance
+        }
+      }
+
+      "with a non-JSON body" - {
+        "fails the future" in forAll(expectedErrorStatuses) { httpStatus =>
+          val result = convertToResult[DummyType](HttpResponse(httpStatus, "not json"))
+          result.failed.futureValue mustBe ApiInternalServerError.defaultInstance
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/pillar2/service/ORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/ORNServiceSpec.scala
@@ -47,7 +47,7 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
     }
 
     "should throw ValidationError for 422 response" in {
-      val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+      val apiFailure   = UnprocessableFailureResponse(UnprocessableFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
       val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
       when(mockOrnConnector.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
@@ -79,7 +79,7 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
       when(mockOrnConnector.submitOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
         .thenReturn(Future.successful(httpResponse))
 
-      intercept[ApiInternalServerError.type] {
+      intercept[ApiInternalServerError] {
         await(service.submitOrn(ornRequest))
       }
     }
@@ -101,7 +101,7 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
     }
 
     "should throw ValidationError for 422 response" in {
-      val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+      val apiFailure   = UnprocessableFailureResponse(UnprocessableFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
       val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
       when(
@@ -151,7 +151,7 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
           )
       ).thenReturn(Future.successful(httpResponse))
 
-      intercept[ApiInternalServerError.type] {
+      intercept[ApiInternalServerError] {
         await(service.getOrn(fromDate, toDate))
       }
     }
@@ -168,7 +168,7 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
     }
 
     "should throw ValidationError for 422 response" in {
-      val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+      val apiFailure   = UnprocessableFailureResponse(UnprocessableFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
       val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
       when(mockOrnConnector.amendOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
@@ -200,7 +200,7 @@ class ORNServiceSpec extends BaseSpec with Generators with ScalaCheckPropertyChe
       when(mockOrnConnector.amendOrn(any[ORNRequest])(any[HeaderCarrier], any[String]))
         .thenReturn(Future.successful(httpResponse))
 
-      intercept[ApiInternalServerError.type] {
+      intercept[ApiInternalServerError] {
         await(service.amendOrn(ornRequest))
       }
     }

--- a/test/uk/gov/hmrc/pillar2/service/ObligationsAndSubmissionsServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/ObligationsAndSubmissionsServiceSpec.scala
@@ -99,11 +99,11 @@ class ObligationsAndSubmissionsServiceSpec extends BaseSpec with Generators with
             ArgumentMatchers.eq(pillar2Id)
           )
       )
-        .thenReturn(Future.failed(ApiInternalServerError))
+        .thenReturn(Future.failed(ApiInternalServerError("errorMessage", "errorCode")))
 
       val error: Throwable = service.getObligationsAndSubmissions(fromDate, toDate).failed.futureValue
 
-      error mustBe ApiInternalServerError
+      error mustBe ApiInternalServerError("errorMessage", "errorCode")
     }
   }
 

--- a/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
@@ -49,7 +49,7 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       }
 
       "should throw ValidationError for 422 response" in {
-        val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+        val apiFailure   = UnprocessableFailureResponse(UnprocessableFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
         val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
         when(mockUKTaxReturnConnector.submitUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
@@ -85,7 +85,7 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
           .thenReturn(Future.successful(httpResponse))
 
         forAll(arbitrary[UKTRSubmission]) { submission =>
-          intercept[ApiInternalServerError.type] {
+          intercept[ApiInternalServerError] {
             await(service.submitUKTaxReturn(submission))
           }
         }
@@ -104,7 +104,7 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
       }
 
       "should throw ValidationError for 422 response" in {
-        val apiFailure   = ApiFailureResponse(ApiFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
+        val apiFailure   = UnprocessableFailureResponse(UnprocessableFailure(ZonedDateTime.parse("2024-03-14T09:26:17Z"), "422", "Validation failed"))
         val httpResponse = HttpResponse(422, Json.toJson(apiFailure).toString())
 
         when(mockUKTaxReturnConnector.amendUKTaxReturn(any[UKTRSubmission])(any[HeaderCarrier], any[String]))
@@ -140,7 +140,7 @@ class UKTaxReturnServiceSpec extends BaseSpec with Generators with ScalaCheckPro
           .thenReturn(Future.successful(httpResponse))
 
         forAll(arbitrary[UKTRSubmission]) { submission =>
-          intercept[ApiInternalServerError.type] {
+          intercept[ApiInternalServerError] {
             await(service.amendUKTaxReturn(submission))
           }
         }


### PR DESCRIPTION
The current error-handling process in this service means the details of the error issued by ETMP is obscured from the frontend. This is problematic for issuing explicit audit events, which sometimes require the error code and message issued by ETMP.

This PR forwards the error code and message on. I am not certain if this is the correct approach to take here.