### PR TITLE
PIL-2874 Fix lz4-java vulnerabilities CVE-2025-66566 and CVE-2025-12183

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "10.4.0"
+  private val bootstrapVersion = "10.6.0"
   private val hmrcMongoVersion = "2.10.0"
 
   val compile: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.10")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.3.1")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"       % "0.13.0")


### PR DESCRIPTION
## Summary

- Upgrades `bootstrap-play` from `10.4.0` to `10.6.0` (`project/AppDependencies.scala`)
- Upgrades `play-sbt-plugin` from `3.0.9` to `3.0.10` (`project/plugins.sbt`)
- `org.lz4:lz4-java` is not a direct dependency — no further changes needed

Both changes together resolve the two transitive `org.lz4:lz4-java` vulnerabilities flagged in the service vulnerability report.