### PR TITLE
Nojira fix medium processing

### DIFF
--- a/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
@@ -41,9 +41,9 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case error: MissingHeaderError  => BadRequest(Json.toJson(Pillar2ApiError(error.code, error.message)))
           case error: ETMPValidationError => UnprocessableEntity(Json.toJson(Pillar2ApiError(error.code, error.message)))
           case error: InvalidJsonError    => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
-          case error @ ApiInternalServerError => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
-          case error @ AuthorizationError     => Unauthorized(Json.toJson(Pillar2ApiError(error.code, error.message)))
-
+          case error @ SubscriptionProcessingError => UnprocessableEntity(Json.toJson(Pillar2ApiError(error.code, error.message)))
+          case error @ ApiInternalServerError      => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
+          case error @ AuthorizationError          => Unauthorized(Json.toJson(Pillar2ApiError(error.code, error.message)))
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)
         Future.successful(ret)

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -32,6 +32,11 @@ case class InvalidJsonError(decodeError: String) extends Pillar2Error {
 
 }
 
+case object SubscriptionProcessingError extends Pillar2Error {
+  val message: String = "Subscription is being processed"
+  val code:    String = "422"
+}
+
 case object ApiInternalServerError extends Pillar2Error {
   val message: String = "Internal server error"
   val code:    String = "003"

--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2.models.*
 import uk.gov.hmrc.pillar2.models.audit.AuditResponseReceived
-import uk.gov.hmrc.pillar2.models.errors.ETMPValidationError
+import uk.gov.hmrc.pillar2.models.errors.SubscriptionProcessingError
 import uk.gov.hmrc.pillar2.models.grs.EntityType
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.*
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
@@ -408,7 +408,7 @@ class SubscriptionService @Inject() (
     for {
       response <- subscriptionConnector.getSubscriptionInformationV2(plrReference)
       _ <- response.status match {
-             case UNPROCESSABLE_ENTITY => Future.failed(ETMPValidationError("422", response.body))
+             case UNPROCESSABLE_ENTITY => Future.failed(SubscriptionProcessingError)
              case _                    => Future.unit
            }
       subscriptionResponse = response.json.as[SubscriptionResponseV2]

--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2.models.*
 import uk.gov.hmrc.pillar2.models.audit.AuditResponseReceived
+import uk.gov.hmrc.pillar2.models.errors.ETMPValidationError
 import uk.gov.hmrc.pillar2.models.grs.EntityType
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.*
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
@@ -406,6 +407,10 @@ class SubscriptionService @Inject() (
   def storeSubscriptionResponseV2(id: String, plrReference: String)(using hc: HeaderCarrier): Future[SubscriptionResponseV2] =
     for {
       response <- subscriptionConnector.getSubscriptionInformationV2(plrReference)
+      _ <- response.status match {
+             case UNPROCESSABLE_ENTITY => Future.failed(ETMPValidationError("422", response.body))
+             case _                    => Future.unit
+           }
       subscriptionResponse = response.json.as[SubscriptionResponseV2]
       _ <- auditService.auditReadSubscriptionSuccessV2(plrReference, subscriptionResponse)
       dataToStore = createCachedObjectV2(subscriptionResponse.success, plrReference)


### PR DESCRIPTION
Fixes an error where when a subscription would return a CANNOT_COMPLETE_REQUEST after a registration (when the registration processing is slow), it would throw an error instead of going to the registration in progress screen.

This only happened when the new amend accounting multi period flag was true as when its off already handled this scenario