### PR TITLE
NOJIRA: Use v2 store in sendAmendedDataV2 to fix post-amend cache refresh

### DIFF
--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -567,7 +567,7 @@ class SubscriptionService @Inject() (
             logger.info(
               s"Successful response received for amend subscription v2 for form ${result.success.formBundleNumber} at ${result.success.processingDate}"
             )
-            storeSubscriptionResponse(
+            storeSubscriptionResponseV2(
               id = id,
               plrReference = etmpAmendRequest.upeDetails.plrReference
             ).as(Done)

--- a/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
@@ -368,11 +368,11 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
   }
 
   "sendAmendedDataV2" - {
-    "call amend API v2 and update cache in case of a successful response" in {
-      val dummyReadResponse = arbitrarySubscriptionResponse.arbitrary.sample.value
+    "call amend API v2 and update cache via v2 store in case of a successful response" in {
+      val dummyReadResponseV2 = arbitrarySubscriptionResponseV2.arbitrary.sample.value
       val subscriptionServiceWithStubbedStoreMethod = new SubscriptionService(mockedCache, mockSubscriptionConnector, mockAuditService) {
-        override def storeSubscriptionResponse(id: String, plrReference: String)(using hc: HeaderCarrier): Future[SubscriptionResponse] =
-          Future.successful(dummyReadResponse)
+        override def storeSubscriptionResponseV2(id: String, plrReference: String)(using hc: HeaderCarrier): Future[SubscriptionResponseV2] =
+          Future.successful(dummyReadResponseV2)
       }
 
       forAll(


### PR DESCRIPTION
## Summary

- `sendAmendedDataV2` was calling `storeSubscriptionResponse` (v1) to refresh the read-subscription cache after a successful v2 amend. The v1 method calls the v1 downstream endpoint, which fails to parse the array-format `accountingPeriod` returned after a multi-period amend, causing a `JsResultException`.
- Switches to `storeSubscriptionResponseV2` which correctly handles the v2 response format.