### PR TITLE
PIL-3079 Logging & Error Handling improvements

### DIFF
--- a/app/uk/gov/hmrc/pillar2/connectors/AccountActivityConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/AccountActivityConnector.scala
@@ -22,8 +22,8 @@ import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.given
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.config.AppConfig
-import uk.gov.hmrc.pillar2.models.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.accountactivity.AccountActivityRequest
+import uk.gov.hmrc.pillar2.models.errors.UnexpectedResponse
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/BTNConnector.scala
@@ -23,8 +23,8 @@ import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.pillar2.config.AppConfig
-import uk.gov.hmrc.pillar2.models.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.btn.BTNRequest
+import uk.gov.hmrc.pillar2.models.errors.UnexpectedResponse
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/pillar2/connectors/FinancialDataConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/FinancialDataConnector.scala
@@ -22,8 +22,8 @@ import play.api.http.Status.OK
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.pillar2.config.AppConfig
+import uk.gov.hmrc.pillar2.models.errors.{FinancialDataError, FinancialDataErrorResponses}
 import uk.gov.hmrc.pillar2.models.financial.FinancialDataResponse
-import uk.gov.hmrc.pillar2.models.{FinancialDataError, FinancialDataErrorResponses}
 
 import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/pillar2/connectors/ORNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/ORNConnector.scala
@@ -23,7 +23,7 @@ import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.pillar2.config.AppConfig
-import uk.gov.hmrc.pillar2.models.UnexpectedResponse
+import uk.gov.hmrc.pillar2.models.errors.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.orn.ORNRequest
 
 import java.time.LocalDate

--- a/app/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnector.scala
+++ b/app/uk/gov/hmrc/pillar2/connectors/ObligationsAndSubmissionsConnector.scala
@@ -20,7 +20,7 @@ import com.google.inject.Inject
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.pillar2.config.AppConfig
-import uk.gov.hmrc.pillar2.models.UnexpectedResponse
+import uk.gov.hmrc.pillar2.models.errors.UnexpectedResponse
 
 import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/pillar2/controllers/FinancialDataController.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/FinancialDataController.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.AuthAction
-import uk.gov.hmrc.pillar2.models.FinancialDataError
+import uk.gov.hmrc.pillar2.models.errors.FinancialDataError
 import uk.gov.hmrc.pillar2.service.FinancialService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.http.HeaderCarrierConverter

--- a/app/uk/gov/hmrc/pillar2/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/actions/AuthAction.scala
@@ -20,7 +20,7 @@ import com.google.inject.{ImplementedBy, Inject}
 import play.api.mvc.*
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, AuthorisedFunctions}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.pillar2.models.errors.AuthorizationError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.AuthorizationError
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/pillar2/controllers/actions/Pillar2HeaderAction.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/actions/Pillar2HeaderAction.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2.controllers.actions
 import com.google.inject.Inject
 import play.api.Logger
 import play.api.mvc.{ActionTransformer, Request, WrappedRequest}
-import uk.gov.hmrc.pillar2.models.errors.MissingHeaderError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.MissingHeaderError
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/pillar2/controllers/package.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/package.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.{JsError, Json}
 import play.api.mvc.Result
 import play.api.mvc.Results.*
 import uk.gov.hmrc.http.HttpResponse
-import uk.gov.hmrc.pillar2.models.FinancialDataErrorResponses
+import uk.gov.hmrc.pillar2.models.errors.FinancialDataErrorResponses
 import uk.gov.hmrc.pillar2.models.hods.ErrorDetails
 
 import scala.util.Try

--- a/app/uk/gov/hmrc/pillar2/controllers/package.scala
+++ b/app/uk/gov/hmrc/pillar2/controllers/package.scala
@@ -18,77 +18,70 @@ package uk.gov.hmrc.pillar2
 
 import play.api.Logger
 import play.api.http.Status.*
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json.{JsError, Json}
 import play.api.mvc.Result
 import play.api.mvc.Results.*
 import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.pillar2.models.FinancialDataErrorResponses
 import uk.gov.hmrc.pillar2.models.hods.ErrorDetails
 
-import scala.util.{Success, Try}
+import scala.util.Try
 
 package object controllers {
+
   extension (error: JsError) {
     def toLogFormat: String = Json.prettyPrint(JsError.toJson(error))
   }
 
-  def convertToResult(
-    httpResponse: HttpResponse
-  )(using logger: Logger): Result =
+  def convertToResult(httpResponse: HttpResponse)(using logger: Logger): Result =
     httpResponse.status match {
+      case OK        => Ok(httpResponse.body)
       case CREATED   => Ok(httpResponse.body)
       case NOT_FOUND => NotFound(httpResponse.body)
       case BAD_REQUEST =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        logDownStreamError(httpResponse.body)
+        logDownstreamError(httpResponse.body)
         BadRequest(httpResponse.body)
-
       case FORBIDDEN =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        logDownStreamError(httpResponse.body)
+        logDownstreamError(httpResponse.body)
         Forbidden(httpResponse.body)
-
       case SERVICE_UNAVAILABLE =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        logDownStreamError(httpResponse.body)
+        logDownstreamError(httpResponse.body)
         ServiceUnavailable(httpResponse.body)
-
       case UNPROCESSABLE_ENTITY =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        logDownStreamError(httpResponse.body)
+        logDownstreamError(httpResponse.body)
         UnprocessableEntity(httpResponse.body)
-
       case INTERNAL_SERVER_ERROR =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        logDownStreamError(httpResponse.body)
+        logDownstreamError(httpResponse.body)
         InternalServerError(httpResponse.body)
-
       case CONFLICT =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        logDownStreamError(httpResponse.body)
+        logDownstreamError(httpResponse.body)
         Conflict(httpResponse.body)
-
-      case OK =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        Ok(httpResponse.body)
-
       case _ =>
-        logger.info(s"convertToResult - Received Response body - ${httpResponse.body}")
-        logDownStreamError(httpResponse.body)
+        logDownstreamError(httpResponse.body)
         InternalServerError(httpResponse.body)
-
     }
 
-  private def logDownStreamError(
-    body:         String
-  )(using logger: Logger): Unit = {
-    val error = Try(Json.parse(body).validate[ErrorDetails])
-    error match {
-      case Success(JsSuccess(value, _)) =>
-        logger.warn(
-          s"Error with submission: ${value.errorDetail.sourceFaultDetail.map(_.detail.mkString)}"
-        )
-      case _ =>
-        logger.warn("Error with submission but return is not a valid json")
+  private def logDownstreamError(body: String)(using logger: Logger): Unit = {
+    val errorMessage: Option[String] =
+      Try(Json.parse(body)).toOption.flatMap { json =>
+        json
+          .asOpt[ErrorDetails]
+          .map { errorDetails =>
+            errorDetails.errorDetail.sourceFaultDetail
+              .map(_.detail.mkString("; "))
+              .getOrElse(s"${errorDetails.errorDetail.errorCode} - ${errorDetails.errorDetail.errorMessage}")
+          }
+          .orElse {
+            json.asOpt[FinancialDataErrorResponses].map { financialDataErrorResponses =>
+              financialDataErrorResponses.failures.map(f => s"${f.code} - ${f.reason}").mkString("; ")
+            }
+          }
+      }
+
+    errorMessage match {
+      case Some(msg) => logger.warn(s"Error with submission: $msg | body: $body")
+      case None      => logger.warn(s"Error with submission - unrecognised json body: $body")
     }
   }
+
 }

--- a/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
@@ -22,6 +22,7 @@ import play.api.libs.json.Json
 import play.api.mvc.Results.*
 import play.api.mvc.{RequestHeader, Result}
 import uk.gov.hmrc.pillar2.models.errors.*
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.*
 
 import javax.inject.Singleton
 import scala.concurrent.Future

--- a/app/uk/gov/hmrc/pillar2/models/errors/ApiErrors.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/ApiErrors.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2.models
+package uk.gov.hmrc.pillar2.models.errors
 
 import play.api.libs.json.{Json, OFormat}
 

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2ApiError.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2ApiError.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2.models.errors
 
 import play.api.libs.json.{Json, OFormat}
 
-case class Pillar2ApiError(code: String, message: String)
+final case class Pillar2ApiError(code: String, message: String)
 
 object Pillar2ApiError {
   given format: OFormat[Pillar2ApiError] = Json.format[Pillar2ApiError]

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -25,12 +25,12 @@ sealed trait Pillar2Error extends Exception {
 
 object Pillar2Error {
 
-  case class MissingHeaderError(headerName: String) extends Pillar2Error {
+  final case class MissingHeaderError(headerName: String) extends Pillar2Error {
     val message: String = s"Missing $headerName header"
     val code:    String = "001"
   }
 
-  case class InvalidJsonError(decodeError: String) extends Pillar2Error {
+  final case class InvalidJsonError(decodeError: String) extends Pillar2Error {
     val message: String = s"Invalid JSON payload: $decodeError"
     val code:    String = "002"
   }

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -17,38 +17,42 @@
 package uk.gov.hmrc.pillar2.models.errors
 
 sealed trait Pillar2Error extends Exception {
-  val message: String
-  val code:    String
+  def message: String
+  def code:    String
 
   override def getMessage: String = s"Code: '$code' Message: '$message'"
 }
 
-case class MissingHeaderError(headerName: String) extends Pillar2Error {
-  val message: String = s"Missing $headerName header"
-  val code:    String = "001"
-}
+object Pillar2Error {
 
-case class InvalidJsonError(decodeError: String) extends Pillar2Error {
-  val message: String = s"Invalid JSON payload: $decodeError"
-  val code:    String = "002"
-}
+  case class MissingHeaderError(headerName: String) extends Pillar2Error {
+    val message: String = s"Missing $headerName header"
+    val code:    String = "001"
+  }
 
-case object ApiInternalServerError extends Pillar2Error {
-  val message: String = "Internal server error"
-  val code:    String = "003"
-}
+  case class InvalidJsonError(decodeError: String) extends Pillar2Error {
+    val message: String = s"Invalid JSON payload: $decodeError"
+    val code:    String = "002"
+  }
 
-case object AuthorizationError extends Pillar2Error {
-  val message: String = "Not Authorized"
-  val code:    String = "401"
-}
+  case object ApiInternalServerError extends Pillar2Error {
+    val message: String = "Internal server error"
+    val code:    String = "003"
+  }
 
-case object SubscriptionProcessingError extends Pillar2Error {
-  val message: String = "Subscription is being processed"
-  val code:    String = "422"
-}
+  case object AuthorizationError extends Pillar2Error {
+    val message: String = "Not Authorized"
+    val code:    String = "401"
+  }
 
-case class ETMPValidationError(validationErrorCode: String, validationError: String) extends Pillar2Error {
-  val message: String = validationError
-  val code:    String = validationErrorCode
+  case object SubscriptionProcessingError extends Pillar2Error {
+    val message: String = "Subscription is being processed"
+    val code:    String = "422"
+  }
+
+  final case class ETMPValidationError(validationErrorCode: String, validationError: String) extends Pillar2Error {
+    val message: String = validationError
+    val code:    String = validationErrorCode
+  }
+
 }

--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -19,6 +19,8 @@ package uk.gov.hmrc.pillar2.models.errors
 sealed trait Pillar2Error extends Exception {
   val message: String
   val code:    String
+
+  override def getMessage: String = s"Code: '$code' Message: '$message'"
 }
 
 case class MissingHeaderError(headerName: String) extends Pillar2Error {
@@ -27,14 +29,8 @@ case class MissingHeaderError(headerName: String) extends Pillar2Error {
 }
 
 case class InvalidJsonError(decodeError: String) extends Pillar2Error {
-  val code:    String = "002"
   val message: String = s"Invalid JSON payload: $decodeError"
-
-}
-
-case object SubscriptionProcessingError extends Pillar2Error {
-  val message: String = "Subscription is being processed"
-  val code:    String = "422"
+  val code:    String = "002"
 }
 
 case object ApiInternalServerError extends Pillar2Error {
@@ -42,12 +38,17 @@ case object ApiInternalServerError extends Pillar2Error {
   val code:    String = "003"
 }
 
-case class ETMPValidationError(validationErrorCode: String, validationError: String) extends Pillar2Error {
-  val code:    String = validationErrorCode
-  val message: String = validationError
-}
-
 case object AuthorizationError extends Pillar2Error {
   val message: String = "Not Authorized"
   val code:    String = "401"
+}
+
+case object SubscriptionProcessingError extends Pillar2Error {
+  val message: String = "Subscription is being processed"
+  val code:    String = "422"
+}
+
+case class ETMPValidationError(validationErrorCode: String, validationError: String) extends Pillar2Error {
+  val message: String = validationError
+  val code:    String = validationErrorCode
 }

--- a/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/FinancialService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2.service
 import play.api.Logging
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.connectors.FinancialDataConnector
-import uk.gov.hmrc.pillar2.models.FinancialDataError
+import uk.gov.hmrc.pillar2.models.errors.FinancialDataError
 import uk.gov.hmrc.pillar2.models.financial.{FinancialDataResponse, FinancialHistory, TransactionHistory}
 import uk.gov.hmrc.pillar2.service.FinancialService.*
 

--- a/app/uk/gov/hmrc/pillar2/service/RepaymentService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/RepaymentService.scala
@@ -20,7 +20,7 @@ import org.apache.pekko.Done
 import play.api.Logging
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.connectors.RepaymentConnector
-import uk.gov.hmrc.pillar2.models.UnexpectedResponse
+import uk.gov.hmrc.pillar2.models.errors.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.hods.repayment.request.RepaymentRequestDetail
 
 import javax.inject.Inject

--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.pillar2.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2.models.*
 import uk.gov.hmrc.pillar2.models.audit.AuditResponseReceived
 import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.SubscriptionProcessingError
+import uk.gov.hmrc.pillar2.models.errors.{JsResultError, UnexpectedResponse}
 import uk.gov.hmrc.pillar2.models.grs.EntityType
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.*
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail

--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2.models.*
 import uk.gov.hmrc.pillar2.models.audit.AuditResponseReceived
-import uk.gov.hmrc.pillar2.models.errors.SubscriptionProcessingError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.SubscriptionProcessingError
 import uk.gov.hmrc.pillar2.models.grs.EntityType
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.*
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
@@ -40,6 +40,7 @@ import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import java.time.LocalDate
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
+
 class SubscriptionService @Inject() (
   repository:            ReadSubscriptionCacheRepository,
   subscriptionConnector: SubscriptionConnector,

--- a/app/uk/gov/hmrc/pillar2/service/package.scala
+++ b/app/uk/gov/hmrc/pillar2/service/package.scala
@@ -29,11 +29,11 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 package object service extends Logging {
+
   private[service] def convertToResult[A](response: HttpResponse)(using reads: Reads[A]): Future[A] = {
     logger.info(s"Converting to API result with status ${response.status}")
     response.status match {
       case 200 | 201 =>
-        // we're using try because HttpResponse.json is not a pure function and can throw an exception
         Try(response.json.validate[A]) match {
           case Success(JsSuccess(success, _)) => Future.successful(success)
           case Success(JsError(error))        => Future.failed(InvalidJsonError(error.toString))
@@ -42,12 +42,13 @@ package object service extends Logging {
       case 422 =>
         Try(response.json.validate[ApiFailureResponse]) match {
           case Success(JsSuccess(apiFailure, _)) =>
+            logger.info(s"ETMPValidationError - Code: '${apiFailure.errors.code}' Text: '${apiFailure.errors.text}'")
             Future.failed(ETMPValidationError(apiFailure.errors.code, apiFailure.errors.text))
           case Success(JsError(_)) => Future.failed(InvalidJsonError(response.body))
           case Failure(exception)  => Future.failed(InvalidJsonError(exception.getMessage))
         }
       case status =>
-        logger.error(s"Received invalid status from downstream: $status")
+        logger.error(s"Received invalid status $status from downstream. Body: ${response.body}")
         Future.failed(ApiInternalServerError)
     }
   }

--- a/app/uk/gov/hmrc/pillar2/service/package.scala
+++ b/app/uk/gov/hmrc/pillar2/service/package.scala
@@ -20,7 +20,7 @@ import play.api.Logging
 import play.api.libs.json.{JsError, JsSuccess, Reads}
 import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.pillar2.models.accountactivity.AccountActivitySuccess
-import uk.gov.hmrc.pillar2.models.errors.*
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip.{ApiFailureResponse, ApiSuccessResponse}
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationsAndSubmissionsResponse
 import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccessResponse, ORNSuccessResponse}

--- a/it/test/uk/gov/hmrc/pillar2/connectors/FinancialDataConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/connectors/FinancialDataConnectorSpec.scala
@@ -21,11 +21,11 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
 import play.api.libs.json.Json
 import play.api.test.Helpers.await
-import uk.gov.hmrc.pillar2.connectors.FinancialDataConnectorSpec._
+import uk.gov.hmrc.pillar2.connectors.FinancialDataConnectorSpec.*
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
+import uk.gov.hmrc.pillar2.models.errors.{FinancialDataError, FinancialDataErrorResponses}
 import uk.gov.hmrc.pillar2.models.financial.{FinancialDataResponse, FinancialItem, FinancialTransaction}
-import uk.gov.hmrc.pillar2.models.{FinancialDataError, FinancialDataErrorResponses}
 
 import java.time.{LocalDate, LocalDateTime}
 

--- a/test/uk/gov/hmrc/pillar2/controllers/AccountActivityControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/AccountActivityControllerSpec.scala
@@ -28,7 +28,8 @@ import play.api.test.Helpers.{contentAsJson, status}
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction, Pillar2HeaderAction}
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.accountactivity.AccountActivitySuccess
-import uk.gov.hmrc.pillar2.models.errors.*
+import uk.gov.hmrc.pillar2.models.errors.Pillar2ApiError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.*
 import uk.gov.hmrc.pillar2.service.AccountActivityService
 
 import java.time.LocalDate

--- a/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/BTNControllerSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.{BaseSpec, UKTaxReturnDataFixture}
 import uk.gov.hmrc.pillar2.models.btn.BTNRequest
-import uk.gov.hmrc.pillar2.models.errors.*
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.*
 import uk.gov.hmrc.pillar2.service.BTNService
 
 import java.time.LocalDate

--- a/test/uk/gov/hmrc/pillar2/controllers/FinancialDataControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/FinancialDataControllerSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.FinancialDataError
+import uk.gov.hmrc.pillar2.models.errors.FinancialDataError
 import uk.gov.hmrc.pillar2.models.financial.*
 import uk.gov.hmrc.pillar2.service.FinancialService
 

--- a/test/uk/gov/hmrc/pillar2/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/ORNControllerSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.{BaseSpec, ORNDataFixture}
-import uk.gov.hmrc.pillar2.models.errors.*
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.*
 import uk.gov.hmrc.pillar2.models.orn.{ORNRequest, ORNSuccess, ORNSuccessResponse}
 import uk.gov.hmrc.pillar2.service.ORNService
 

--- a/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -31,7 +31,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.errors.ApiInternalServerError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.ApiInternalServerError
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.*
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}

--- a/test/uk/gov/hmrc/pillar2/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/SubscriptionControllerSpec.scala
@@ -34,9 +34,10 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
+import uk.gov.hmrc.pillar2.models.UserAnswers
+import uk.gov.hmrc.pillar2.models.errors.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.*
 import uk.gov.hmrc.pillar2.models.subscription.SubscriptionRequestParameters
-import uk.gov.hmrc.pillar2.models.{UnexpectedResponse, UserAnswers}
 import uk.gov.hmrc.pillar2.repositories.{ReadSubscriptionCacheRepository, RegistrationCacheRepository}
 import uk.gov.hmrc.pillar2.service.SubscriptionService
 
@@ -291,7 +292,7 @@ class SubscriptionControllerSpec extends BaseSpec with Generators with ScalaChec
           .thenReturn(Future.failed(UnexpectedResponse))
         val request = FakeRequest(GET, routes.SubscriptionController.readAndCacheSubscription("id", "pillar2Id").url)
         val result  = route(application, request).value
-        result.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+        result.failed.futureValue mustEqual UnexpectedResponse
       }
     }
 
@@ -326,7 +327,7 @@ class SubscriptionControllerSpec extends BaseSpec with Generators with ScalaChec
           .thenReturn(Future.failed(UnexpectedResponse))
         val request = FakeRequest(GET, routes.SubscriptionController.readAndCacheSubscriptionV2("id", "pillar2Id").url)
         val result  = route(application, request).value
-        result.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+        result.failed.futureValue mustEqual UnexpectedResponse
       }
     }
 
@@ -360,7 +361,7 @@ class SubscriptionControllerSpec extends BaseSpec with Generators with ScalaChec
         when(mockSubscriptionService.readSubscriptionData(any[String]())(using any[HeaderCarrier]())).thenReturn(Future.failed(UnexpectedResponse))
         val request = FakeRequest(GET, routes.SubscriptionController.readSubscription("pillar2Id").url)
         val result  = route(application, request).value
-        result.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+        result.failed.futureValue mustEqual UnexpectedResponse
       }
     }
 
@@ -380,7 +381,7 @@ class SubscriptionControllerSpec extends BaseSpec with Generators with ScalaChec
         when(mockSubscriptionService.readSubscriptionDataV2(any[String]())(using any[HeaderCarrier]())).thenReturn(Future.failed(UnexpectedResponse))
         val request = FakeRequest(GET, routes.SubscriptionController.readSubscriptionV2("pillar2Id").url)
         val result  = route(application, request).value
-        result.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+        result.failed.futureValue mustEqual UnexpectedResponse
       }
     }
 

--- a/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/UKTaxReturnControllerSpec.scala
@@ -31,7 +31,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.controllers.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.errors.*
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.*
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 import uk.gov.hmrc.pillar2.service.UKTaxReturnService
 

--- a/test/uk/gov/hmrc/pillar2/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/actions/AuthActionSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.auth.core.{AuthConnector, MissingBearerToken}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.pillar2.models.errors.AuthorizationError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.AuthorizationError
 
 import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/uk/gov/hmrc/pillar2/controllers/actions/Pillar2HeaderActionTest.scala
+++ b/test/uk/gov/hmrc/pillar2/controllers/actions/Pillar2HeaderActionTest.scala
@@ -21,7 +21,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers.shouldEqual
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import uk.gov.hmrc.pillar2.models.errors.MissingHeaderError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.MissingHeaderError
 
 import scala.concurrent.ExecutionContext.Implicits.*
 

--- a/test/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandlerSpec.scala
@@ -23,7 +23,8 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
-import uk.gov.hmrc.pillar2.models.errors.*
+import uk.gov.hmrc.pillar2.models.errors.Pillar2ApiError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.*
 
 class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
 

--- a/test/uk/gov/hmrc/pillar2/models/errors/Pillar2ErrorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/models/errors/Pillar2ErrorSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.models.errors
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+class Pillar2ErrorSpec extends AnyFreeSpec with Matchers {
+
+  "Pillar2Error.getMessage must override the Throwable.getMessage and" - {
+
+    "return the custom detail message for MissingHeaderError" in {
+      val error = MissingHeaderError("X-Test-Header")
+      error.getMessage mustBe "Code: '001' Message: 'Missing X-Test-Header header'"
+    }
+
+    "return the custom detail message for InvalidJsonError" in {
+      val error = InvalidJsonError("{\"invalidKey\": \"value\"}")
+      error.getMessage mustBe "Code: '002' Message: 'Invalid JSON payload: {\"invalidKey\": \"value\"}'"
+    }
+
+    "return the custom detail message for ApiInternalServerError" in {
+      val error = ApiInternalServerError
+      error.getMessage mustBe "Code: '003' Message: 'Internal server error'"
+    }
+
+    "return the custom detail message for AuthorizationError" in {
+      val error = AuthorizationError
+      error.getMessage mustBe "Code: '401' Message: 'Not Authorized'"
+    }
+
+    "return the custom detail message for SubscriptionProcessingError" in {
+      val error = SubscriptionProcessingError
+      error.getMessage mustBe "Code: '422' Message: 'Subscription is being processed'"
+    }
+
+    "return the custom detail message for ETMPValidationError" in {
+      val error = ETMPValidationError("089", "ID number missing or invalid")
+      error.getMessage mustBe "Code: '089' Message: 'ID number missing or invalid'"
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/pillar2/models/errors/Pillar2ErrorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/models/errors/Pillar2ErrorSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.pillar2.models.errors
 
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.*
 
 class Pillar2ErrorSpec extends AnyFreeSpec with Matchers {
 

--- a/test/uk/gov/hmrc/pillar2/service/AccountActivityServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/AccountActivityServiceSpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.pillar2.connectors.AccountActivityConnector
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.accountactivity.*
-import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip.{ApiFailure, ApiFailureResponse}
 
 import java.time.{LocalDate, ZoneOffset, ZonedDateTime}

--- a/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/FinancialServiceSpec.scala
@@ -26,7 +26,7 @@ import play.api.test.Helpers.await
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.FinancialDataError
+import uk.gov.hmrc.pillar2.models.errors.FinancialDataError
 import uk.gov.hmrc.pillar2.models.financial.*
 import uk.gov.hmrc.pillar2.service.FinancialServiceSpec.*
 

--- a/test/uk/gov/hmrc/pillar2/service/ORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/ORNServiceSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers.await
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.{BaseSpec, ORNDataFixture}
-import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip.*
 import uk.gov.hmrc.pillar2.models.orn.{ORNRequest, ORNSuccess, ORNSuccessResponse}
 

--- a/test/uk/gov/hmrc/pillar2/service/ObligationsAndSubmissionsServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/ObligationsAndSubmissionsServiceSpec.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.errors.ApiInternalServerError
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.ApiInternalServerError
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.*
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationType.{GIR, UKTR}

--- a/test/uk/gov/hmrc/pillar2/service/RepaymentServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/RepaymentServiceSpec.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.JsObject
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.UnexpectedResponse
+import uk.gov.hmrc.pillar2.models.errors.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.hods.repayment.request.RepaymentRequestDetail
 
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
@@ -27,8 +27,8 @@ import play.api.libs.json.{JsObject, JsValue, Json}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.UnexpectedResponse
 import uk.gov.hmrc.pillar2.models.audit.AuditResponseReceived
+import uk.gov.hmrc.pillar2.models.errors.{JsResultError, UnexpectedResponse}
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.*
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
 import uk.gov.hmrc.pillar2.repositories.ReadSubscriptionCacheRepository
@@ -161,7 +161,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
 
         val resultFuture = service.storeSubscriptionResponse(mockId, plrReference)
 
-        resultFuture.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+        resultFuture.failed.futureValue mustEqual UnexpectedResponse
       }
     }
   }
@@ -188,7 +188,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
 
         val resultFuture = service.storeSubscriptionResponseV2(mockId, plrReference)
 
-        resultFuture.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+        resultFuture.failed.futureValue mustEqual UnexpectedResponse
       }
     }
   }
@@ -214,7 +214,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
       when(mockAuditService.auditReadSubscriptionFailure(any[String](), any[Int](), any[JsValue]())(using any[HeaderCarrier]()))
         .thenReturn(Future.successful(AuditResult.Success))
       val resultFuture = service.readSubscriptionData("plrReference")
-      resultFuture.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+      resultFuture.failed.futureValue mustEqual UnexpectedResponse
     }
 
     "handle LimitedLiabilityPartnership entity type correctly" - {
@@ -272,7 +272,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
       when(mockAuditService.auditReadSubscriptionFailure(any[String](), any[Int](), any[JsValue]())(using any[HeaderCarrier]()))
         .thenReturn(Future.successful(AuditResult.Success))
       val resultFuture = service.readSubscriptionDataV2("plrReference")
-      resultFuture.failed.futureValue mustEqual uk.gov.hmrc.pillar2.models.UnexpectedResponse
+      resultFuture.failed.futureValue mustEqual UnexpectedResponse
     }
 
     "handle LimitedLiabilityPartnership entity type correctly" - {
@@ -343,7 +343,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
 
       forAll(arbitraryAmendSubscriptionSuccess.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
         service.sendAmendedData(id, validAmendObject).map { response =>
-          response mustBe uk.gov.hmrc.pillar2.models.JsResultError
+          response mustBe JsResultError
         }
       }
     }
@@ -360,7 +360,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
 
       forAll(arbitraryAmendSubscriptionSuccess.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
         service.sendAmendedData(id, validAmendObject).map { response =>
-          response mustBe uk.gov.hmrc.pillar2.models.UnexpectedResponse
+          response mustBe UnexpectedResponse
         }
       }
     }
@@ -410,7 +410,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
 
       forAll(arbitraryAmendSubscriptionSuccessV2.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
         service.sendAmendedDataV2(id, validAmendObject).map { response =>
-          response mustBe uk.gov.hmrc.pillar2.models.JsResultError
+          response mustBe JsResultError
         }
       }
     }
@@ -427,7 +427,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
 
       forAll(arbitraryAmendSubscriptionSuccessV2.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
         service.sendAmendedDataV2(id, validAmendObject).map { response =>
-          response mustBe uk.gov.hmrc.pillar2.models.UnexpectedResponse
+          response mustBe UnexpectedResponse
         }
       }
     }

--- a/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/UKTaxReturnServiceSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers.await
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
-import uk.gov.hmrc.pillar2.models.errors.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip.*
 import uk.gov.hmrc.pillar2.models.hip.uktrsubmissions.UKTRSubmission
 


### PR DESCRIPTION
- The `Pillar2Error` extends `Exception` but the `getMessage` method requires `cause` and `message`. Because Pillar2Error uses custom `message` and `code`, exceptions are not properly formatted when logged. By overriding it we log both the `code` and `message`, making debugging easier.
- The `logDownstreamError` method in `controllers/package.scala` validates only against `ErrorDetails` but we seem to be getting `FinancialDataErrorResponses`. The method was refactored to cater for both.
- Improved logging in the `controllers.convertToResult()` (removed duplicate logging).