### PR TITLE
PIL-3131 Suppressing ETMPValidationError from filling in the stack trace

### DIFF
--- a/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2/models/errors/Pillar2Error.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.pillar2.models.errors
 
+import scala.util.control.NoStackTrace
+
 sealed trait Pillar2Error extends Exception {
   def message: String
   def code:    String
@@ -50,7 +52,7 @@ object Pillar2Error {
     val code:    String = "422"
   }
 
-  final case class ETMPValidationError(validationErrorCode: String, validationError: String) extends Pillar2Error {
+  final case class ETMPValidationError(validationErrorCode: String, validationError: String) extends Pillar2Error with NoStackTrace {
     val message: String = validationError
     val code:    String = validationErrorCode
   }

--- a/test/uk/gov/hmrc/pillar2/models/errors/Pillar2ErrorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/models/errors/Pillar2ErrorSpec.scala
@@ -53,6 +53,13 @@ class Pillar2ErrorSpec extends AnyFreeSpec with Matchers {
       val error = ETMPValidationError("089", "ID number missing or invalid")
       error.getMessage mustBe "Code: '089' Message: 'ID number missing or invalid'"
     }
-
   }
+
+  "Pillar2Error.ETMPValidationError must" - {
+    "not fill in the stack trace" in {
+      val error = ETMPValidationError("014", "No data found")
+      error.getStackTrace mustBe empty
+    }
+  }
+
 }


### PR DESCRIPTION
Use the `NoStackTrace` trait to stop ETMPValidationError from filling in the stack trace.