### PR TITLE
PIL-3167 Subscription Amendment fix - 422s not escalated to 500s

### DIFF
--- a/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2/handlers/Pillar2ErrorHandler.scala
@@ -46,7 +46,7 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case error @ ApiInternalServerError      => InternalServerError(Json.toJson(Pillar2ApiError(error.code, error.message)))
           case error @ AuthorizationError          => Unauthorized(Json.toJson(Pillar2ApiError(error.code, error.message)))
         }
-        logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)
+        logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} status code. Exception: ", exception)
         Future.successful(ret)
       case _ =>
         logger.warn(s"Caught unhandled exception. Returning InternalServerError", exception)

--- a/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/pillar2/service/SubscriptionService.scala
@@ -563,24 +563,17 @@ class SubscriptionService @Inject() (
   def sendAmendedDataV2(id: String, amendData: AmendSubscriptionSuccessV2)(using hc: HeaderCarrier): Future[Done] = {
     val etmpAmendRequest = ETMPAmendSubscriptionSuccessV2(amendData)
     subscriptionConnector.amendSubscriptionInformationV2(etmpAmendRequest).flatMap { response =>
-      if response.status == 200 then {
-        response.json.validate[AmendResponse] match {
-          case JsSuccess(result, _) =>
-            logger.info(
-              s"Successful response received for amend subscription v2 for form ${result.success.formBundleNumber} at ${result.success.processingDate}"
-            )
-            storeSubscriptionResponseV2(
-              id = id,
-              plrReference = etmpAmendRequest.upeDetails.plrReference
-            ).as(Done)
-          case _ => Future.failed(JsResultError)
-        }
-      } else {
+      auditService.auditAmendSubscriptionV2(
+        requestData = amendData,
+        responseData = AuditResponseReceived(response.status, response.json)
+      ) >> convertToAmendSubscriptionResult(response).flatMap { amendResponse =>
         logger.info(
-          s"Unsuccessful response received for amend subscription v2 with ${response.status} status and body: ${response.body} "
+          s"Successful response received for amend subscription v2 for form ${amendResponse.success.formBundleNumber} at ${amendResponse.success.processingDate}"
         )
-        auditService.auditAmendSubscriptionV2(requestData = amendData, responseData = AuditResponseReceived(response.status, response.json)) >>
-          Future.failed(UnexpectedResponse)
+        storeSubscriptionResponseV2(
+          id = id,
+          plrReference = etmpAmendRequest.upeDetails.plrReference
+        ).as(Done)
       }
     }
   }

--- a/app/uk/gov/hmrc/pillar2/service/package.scala
+++ b/app/uk/gov/hmrc/pillar2/service/package.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.pillar2.models.accountactivity.AccountActivitySuccess
 import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip.{ApiFailureResponse, ApiSuccessResponse}
+import uk.gov.hmrc.pillar2.models.hods.subscription.common.AmendResponse
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationsAndSubmissionsResponse
 import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccessResponse, ORNSuccessResponse}
 
@@ -67,4 +68,7 @@ package object service extends Logging {
 
   private[service] def convertToGetORNApiResult(response: HttpResponse): Future[GetORNSuccessResponse] =
     convertToResult[GetORNSuccessResponse](response)
+
+  private[service] def convertToAmendSubscriptionResult(response: HttpResponse): Future[AmendResponse] =
+    convertToResult[AmendResponse](response)
 }

--- a/app/uk/gov/hmrc/pillar2/service/package.scala
+++ b/app/uk/gov/hmrc/pillar2/service/package.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.pillar2.models.accountactivity.AccountActivitySuccess
 import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.hip.{ApiFailureResponse, ApiSuccessResponse}
+import uk.gov.hmrc.pillar2.models.hods.ErrorDetails
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.AmendResponse
 import uk.gov.hmrc.pillar2.models.obligationsAndSubmissions.ObligationsAndSubmissionsResponse
 import uk.gov.hmrc.pillar2.models.orn.{GetORNSuccessResponse, ORNSuccessResponse}
@@ -54,6 +55,29 @@ package object service extends Logging {
     }
   }
 
+  private[service] def convertToAmendSubscriptionResult(response: HttpResponse): Future[AmendResponse] = {
+    logger.info(s"Converting amend subscription result with status ${response.status}")
+    response.status match {
+      case 200 | 201 =>
+        Try(response.json.validate[AmendResponse]) match {
+          case Success(JsSuccess(success, _)) => Future.successful(success)
+          case Success(JsError(error))        => Future.failed(InvalidJsonError(error.toString))
+          case Failure(exception)             => Future.failed(InvalidJsonError(exception.getMessage))
+        }
+      case 422 =>
+        Try(response.json.validate[ErrorDetails]) match {
+          case Success(JsSuccess(failure, _)) =>
+            logger.info(s"ETMPValidationError - Code: '${failure.errorDetail.errorCode}' Text: '${failure.errorDetail.errorMessage}'")
+            Future.failed(ETMPValidationError(failure.errorDetail.errorCode, failure.errorDetail.errorMessage))
+          case Success(JsError(_)) => Future.failed(InvalidJsonError(response.body))
+          case Failure(exception)  => Future.failed(InvalidJsonError(exception.getMessage))
+        }
+      case status =>
+        logger.error(s"Received invalid status $status from downstream. Body: ${response.body}")
+        Future.failed(ApiInternalServerError)
+    }
+  }
+
   private[service] def convertToAccountActivityResult(response: HttpResponse): Future[AccountActivitySuccess] =
     convertToResult[AccountActivitySuccess](response)
 
@@ -69,6 +93,6 @@ package object service extends Logging {
   private[service] def convertToGetORNApiResult(response: HttpResponse): Future[GetORNSuccessResponse] =
     convertToResult[GetORNSuccessResponse](response)
 
-  private[service] def convertToAmendSubscriptionResult(response: HttpResponse): Future[AmendResponse] =
-    convertToResult[AmendResponse](response)
+//  private[service] def convertToAmendSubscriptionResult(response: HttpResponse): Future[AmendResponse] =
+//    convertToAmendSubscriptionResult[AmendResponse](response)
 }

--- a/it/test/uk/gov/hmrc/pillar2/controllers/SubscriptionControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/controllers/SubscriptionControllerIntegrationSpec.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2.controllers
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.OptionValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers.mustEqual
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2.generators.Generators
+import uk.gov.hmrc.pillar2.helpers.AuthStubs
+import uk.gov.hmrc.pillar2.helpers.wiremock.WireMockServerHandler
+import uk.gov.hmrc.pillar2.models.errors.Pillar2ApiError
+import uk.gov.hmrc.pillar2.models.hods.subscription.common.AmendSubscriptionSuccessV2
+
+import java.net.URI
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.*
+import scala.concurrent.duration.DurationInt
+
+class SubscriptionControllerIntegrationSpec
+    extends AnyFunSuite
+    with GuiceOneServerPerSuite
+    with WireMockServerHandler
+    with Generators
+    with AuthStubs
+    with OptionValues {
+
+  override def fakeApplication(): Application = new GuiceApplicationBuilder()
+    .configure("microservice.services.auth.port" -> wiremockPort)
+    .configure("microservice.services.amend-subscription-v2.port" -> wiremockPort)
+    .configure("metrics.enabled" -> false)
+    .build()
+
+  lazy val url = URI.create(s"http://localhost:$port${routes.SubscriptionController.amendSubscriptionV2(id).url}").toURL
+
+  val id = "Int-c75cfd09-f945-41a8-90db-a93177a7663c"
+
+  test("A downstream 422 is mapped to a 422 carrying the validation error code and text") {
+    stubAuthenticate()
+    server.stubFor(
+      put(urlEqualTo("/pillar2/subscription/v2"))
+        .willReturn(
+          aResponse()
+            .withStatus(422)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              Json
+                .obj("errors" -> Json.obj("processingDate" -> "2026-06-30T12:13:30Z", "code" -> "014", "text" -> "No subscription data found"))
+                .toString()
+            )
+        )
+    )
+
+    val httpClient = app.injector.instanceOf[HttpClientV2]
+    given headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
+      .withExtraHeaders("Content-Type" -> "application/json")
+    val request = httpClient.put(url).withBody(Json.toJson(arbitrary[AmendSubscriptionSuccessV2].sample.value))
+    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+
+    result.status mustEqual 422
+    val error = result.json.as[Pillar2ApiError]
+    error.code mustEqual "014"
+    error.message mustEqual "No subscription data found"
+  }
+
+  test("The downstream validation code is propagated to the caller unchanged") {
+    stubAuthenticate()
+    server.stubFor(
+      put(urlEqualTo("/pillar2/subscription/v2"))
+        .willReturn(
+          aResponse()
+            .withStatus(422)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              Json
+                .obj("errors" -> Json.obj("processingDate" -> "2026-06-30T12:13:30Z", "code" -> "089", "text" -> "ID number missing or invalid"))
+                .toString()
+            )
+        )
+    )
+
+    val httpClient = app.injector.instanceOf[HttpClientV2]
+    given headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
+      .withExtraHeaders("Content-Type" -> "application/json")
+    val request = httpClient.put(url).withBody(Json.toJson(arbitrary[AmendSubscriptionSuccessV2].sample.value))
+    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+
+    result.status mustEqual 422
+    val error = result.json.as[Pillar2ApiError]
+    error.code mustEqual "089"
+    error.message mustEqual "ID number missing or invalid"
+  }
+
+  test("An unmapped downstream status is mapped to a 500 with the generic API error code") {
+    stubAuthenticate()
+    server.stubFor(
+      put(urlEqualTo("/pillar2/subscription/v2"))
+        .willReturn(
+          aResponse()
+            .withStatus(503)
+            .withHeader("Content-Type", "application/json")
+            .withBody(Json.obj("code" -> "503", "text" -> "Service unavailable").toString())
+        )
+    )
+
+    val httpClient = app.injector.instanceOf[HttpClientV2]
+    given headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
+      .withExtraHeaders("Content-Type" -> "application/json")
+    val request = httpClient.put(url).withBody(Json.toJson(arbitrary[AmendSubscriptionSuccessV2].sample.value))
+    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+
+    result.status mustEqual 500
+    val error = result.json.as[Pillar2ApiError]
+    error.code mustEqual "003"
+  }
+
+  test("An unauthorised request is rejected with 401 and the downstream service is never called") {
+    server.stubFor(
+      post(urlEqualTo("/auth/authorise"))
+        .willReturn(
+          aResponse()
+            .withStatus(401)
+            .withHeader("WWW-Authenticate", "MDTP detail=\"MissingBearerToken\"")
+        )
+    )
+
+    val httpClient = app.injector.instanceOf[HttpClientV2]
+    given headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
+      .withExtraHeaders("Content-Type" -> "application/json")
+    val request = httpClient.put(url).withBody(Json.toJson(arbitrary[AmendSubscriptionSuccessV2].sample.value))
+    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+
+    result.status mustEqual 401
+    val error = result.json.as[Pillar2ApiError]
+    error.code mustEqual "401"
+    server.verify(0, putRequestedFor(urlEqualTo("/pillar2/subscription/v2")))
+  }
+
+  test("An invalid request body is rejected with 400 and the downstream service is never called") {
+    stubAuthenticate()
+
+    val httpClient = app.injector.instanceOf[HttpClientV2]
+    given headerCarrier: HeaderCarrier = HeaderCarrier(authorization = Option(Authorization("bearertoken")))
+      .withExtraHeaders("Content-Type" -> "application/json")
+    val request = httpClient.put(url).withBody(Json.obj("unexpected" -> "field"))
+    val result  = Await.result(request.execute[HttpResponse], 5.seconds)
+
+    result.status mustEqual 400
+    val error = result.json.as[Pillar2ApiError]
+    error.code mustEqual "400"
+    server.verify(0, putRequestedFor(urlEqualTo("/pillar2/subscription/v2")))
+  }
+
+}

--- a/it/test/uk/gov/hmrc/pillar2/controllers/SubscriptionControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2/controllers/SubscriptionControllerIntegrationSpec.scala
@@ -68,7 +68,14 @@ class SubscriptionControllerIntegrationSpec
             .withHeader("Content-Type", "application/json")
             .withBody(
               Json
-                .obj("errors" -> Json.obj("processingDate" -> "2026-06-30T12:13:30Z", "code" -> "014", "text" -> "No subscription data found"))
+                .obj(
+                  "errorDetail" -> Json.obj(
+                    "timestamp"    -> "2023-02-14T12:58:44Z",
+                    "errorCode"    -> "014",
+                    "errorMessage" -> "No subscription data found",
+                    "source"       -> "Back End"
+                  )
+                )
                 .toString()
             )
         )
@@ -96,7 +103,14 @@ class SubscriptionControllerIntegrationSpec
             .withHeader("Content-Type", "application/json")
             .withBody(
               Json
-                .obj("errors" -> Json.obj("processingDate" -> "2026-06-30T12:13:30Z", "code" -> "089", "text" -> "ID number missing or invalid"))
+                .obj(
+                  "errorDetail" -> Json.obj(
+                    "timestamp"    -> "2023-02-14T12:58:44Z",
+                    "errorCode"    -> "014",
+                    "errorMessage" -> "No subscription data found",
+                    "source"       -> "Back End"
+                  )
+                )
                 .toString()
             )
         )
@@ -110,8 +124,8 @@ class SubscriptionControllerIntegrationSpec
 
     result.status mustEqual 422
     val error = result.json.as[Pillar2ApiError]
-    error.code mustEqual "089"
-    error.message mustEqual "ID number missing or invalid"
+    error.code mustEqual "014"
+    error.message mustEqual "No subscription data found"
   }
 
   test("An unmapped downstream status is mapped to a 500 with the generic API error code") {

--- a/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2.generators.Generators
 import uk.gov.hmrc.pillar2.helpers.BaseSpec
 import uk.gov.hmrc.pillar2.models.audit.AuditResponseReceived
+import uk.gov.hmrc.pillar2.models.errors.Pillar2Error.{ApiInternalServerError, ETMPValidationError, InvalidJsonError}
 import uk.gov.hmrc.pillar2.models.errors.{JsResultError, UnexpectedResponse}
 import uk.gov.hmrc.pillar2.models.hods.subscription.common.*
 import uk.gov.hmrc.pillar2.models.hods.subscription.request.RequestDetail
@@ -349,7 +350,6 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
     }
 
     "return failure in case of a non-200 response" in {
-
       when(
         mockSubscriptionConnector.amendSubscriptionInformation(any[ETMPAmendSubscriptionSuccess]())(using
           any[HeaderCarrier](),
@@ -364,26 +364,23 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
         }
       }
     }
-
   }
 
   "sendAmendedDataV2" - {
-    "call amend API v2 and update cache via v2 store in case of a successful response" in {
-      val dummyReadResponseV2 = arbitrarySubscriptionResponseV2.arbitrary.sample.value
+    "call amend API v2, audit, and update cache via v2 store in case of a successful response" in {
+      val testSubscriptionResponseV2 = arbitrarySubscriptionResponseV2.arbitrary.sample.value
       val subscriptionServiceWithStubbedStoreMethod = new SubscriptionService(mockedCache, mockSubscriptionConnector, mockAuditService) {
         override def storeSubscriptionResponseV2(id: String, plrReference: String)(using hc: HeaderCarrier): Future[SubscriptionResponseV2] =
-          Future.successful(dummyReadResponseV2)
+          Future.successful(testSubscriptionResponseV2)
       }
 
-      forAll(
-        arbitraryAmendSubscriptionSuccessV2.arbitrary,
-        arbMockId.arbitrary
-      ) { (validAmendObject, id) =>
+      when(
+        mockAuditService.auditAmendSubscriptionV2(any[AmendSubscriptionSuccessV2], any[AuditResponseReceived])(using any[HeaderCarrier])
+      ).thenReturn(Future.successful(AuditResult.Success))
+
+      forAll(arbitraryAmendSubscriptionSuccessV2.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
         val etmpAmendResponse = AmendResponse(
-          AmendSubscriptionSuccessResponse(
-            processingDate = LocalDate.now().toString,
-            formBundleNumber = "test-form-bundle-number"
-          )
+          AmendSubscriptionSuccessResponse(processingDate = LocalDate.now().toString, formBundleNumber = "test-form-bundle-number")
         )
         val fakeAmendResponse = HttpResponse(OK, Json.toJson(etmpAmendResponse).toString())
 
@@ -392,46 +389,71 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
             any[HeaderCarrier](),
             any[ExecutionContext]()
           )
-        )
-          .thenReturn(Future.successful(fakeAmendResponse))
+        ).thenReturn(Future.successful(fakeAmendResponse))
 
         subscriptionServiceWithStubbedStoreMethod.sendAmendedDataV2(id, validAmendObject).futureValue mustBe Done
       }
     }
-    "return failure in case of an unusual json response" in {
+
+    "fail with ETMPValidationError, preserving the error code and text, on a 422 response" in {
+      when(
+        mockAuditService.auditAmendSubscriptionV2(any[AmendSubscriptionSuccessV2], any[AuditResponseReceived])(using any[HeaderCarrier])
+      ).thenReturn(Future.successful(AuditResult.Success))
+
+      val failureBody = Json.obj(
+        "errors" -> Json.obj(
+          "processingDate" -> "2026-06-30T12:13:30Z",
+          "code"           -> "014",
+          "text"           -> "No subscription data found"
+        )
+      )
 
       when(
         mockSubscriptionConnector.amendSubscriptionInformationV2(any[ETMPAmendSubscriptionSuccessV2]())(using
           any[HeaderCarrier](),
           any[ExecutionContext]()
         )
-      )
-        .thenReturn(Future.successful(HttpResponse.apply(status = OK, json = JsObject.empty, Map.empty)))
+      ).thenReturn(Future.successful(HttpResponse(UNPROCESSABLE_ENTITY, failureBody.toString())))
 
       forAll(arbitraryAmendSubscriptionSuccessV2.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
-        service.sendAmendedDataV2(id, validAmendObject).map { response =>
-          response mustBe JsResultError
-        }
+        service.sendAmendedDataV2(id, validAmendObject).failed.futureValue mustEqual
+          ETMPValidationError("014", "No subscription data found")
       }
     }
 
-    "return failure in case of a non-200 response" in {
+    "fail with InvalidJsonError when a 200 response has an unparseable body" in {
+      when(
+        mockAuditService.auditAmendSubscriptionV2(any[AmendSubscriptionSuccessV2], any[AuditResponseReceived])(using any[HeaderCarrier])
+      ).thenReturn(Future.successful(AuditResult.Success))
 
       when(
         mockSubscriptionConnector.amendSubscriptionInformationV2(any[ETMPAmendSubscriptionSuccessV2]())(using
           any[HeaderCarrier](),
           any[ExecutionContext]()
         )
-      )
-        .thenReturn(Future.successful(HttpResponse.apply(BAD_REQUEST, "Bad Request")))
+      ).thenReturn(Future.successful(HttpResponse(OK, JsObject.empty, Map.empty)))
 
       forAll(arbitraryAmendSubscriptionSuccessV2.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
-        service.sendAmendedDataV2(id, validAmendObject).map { response =>
-          response mustBe UnexpectedResponse
-        }
+        service.sendAmendedDataV2(id, validAmendObject).failed.futureValue mustBe a[InvalidJsonError]
       }
     }
 
+    "fail with ApiInternalServerError on any other non-200 status" in {
+      when(
+        mockAuditService.auditAmendSubscriptionV2(any[AmendSubscriptionSuccessV2], any[AuditResponseReceived])(using any[HeaderCarrier])
+      ).thenReturn(Future.successful(AuditResult.Success))
+
+      when(
+        mockSubscriptionConnector.amendSubscriptionInformationV2(any[ETMPAmendSubscriptionSuccessV2]())(using
+          any[HeaderCarrier](),
+          any[ExecutionContext]()
+        )
+      ).thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Json.obj("code" -> "400", "text" -> "Bad Request").toString())))
+
+      forAll(arbitraryAmendSubscriptionSuccessV2.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
+        service.sendAmendedDataV2(id, validAmendObject).failed.futureValue mustBe ApiInternalServerError
+      }
+    }
   }
 
 }

--- a/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2/service/SubscriptionServiceSpec.scala
@@ -401,10 +401,12 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
       ).thenReturn(Future.successful(AuditResult.Success))
 
       val failureBody = Json.obj(
-        "errors" -> Json.obj(
-          "processingDate" -> "2026-06-30T12:13:30Z",
-          "code"           -> "014",
-          "text"           -> "No subscription data found"
+        "errorDetail" -> Json.obj(
+          "timestamp"         -> "2023-02-14T12:58:44Z",
+          "errorCode"         -> "422",
+          "errorMessage"      -> "Request Not Processed",
+          "source"            -> "Back End",
+          "sourceFaultDetail" -> Json.obj("detail" -> Json.arr("001 - Request Not Processed"))
         )
       )
 
@@ -417,7 +419,7 @@ class SubscriptionServiceSpec extends BaseSpec with Generators with ScalaCheckPr
 
       forAll(arbitraryAmendSubscriptionSuccessV2.arbitrary, arbMockId.arbitrary) { (validAmendObject, id) =>
         service.sendAmendedDataV2(id, validAmendObject).failed.futureValue mustEqual
-          ETMPValidationError("014", "No subscription data found")
+          ETMPValidationError("422", "Request Not Processed")
       }
     }
 


### PR DESCRIPTION
422s on amendment of subscription no longer gets escalated to 500.
Added auditing for success cases of amendment (previously only had for failures)